### PR TITLE
Remove ms_dotnet4 computed version's attributes

### DIFF
--- a/attributes/ms_dotnet4.rb
+++ b/attributes/ms_dotnet4.rb
@@ -49,8 +49,3 @@ default['ms_dotnet']['v4']['4.5.2']['min_nt_version']      = 6.0
 default['ms_dotnet']['v4']['4.5.2']['max_nt_version']      = 6.3
 
 default['ms_dotnet4']['version']                           = '4.0'
-
-version = node['ms_dotnet4']['version']
-node['ms_dotnet']['v4'][version].each do |k, v|
-  default['ms_dotnet4'][k] = v
-end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,5 +4,5 @@ maintainer_email 'j_mauro@criteo.com'
 license          'All rights reserved'
 description      'Installs/Configures ms_dotnet'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.0.0'
+version          '1.1.0'
 depends          'windows'

--- a/recipes/ms_dotnet4.rb
+++ b/recipes/ms_dotnet4.rb
@@ -20,21 +20,23 @@
 if platform? 'windows'
   include_recipe 'ms_dotnet'
 
+  version = node['ms_dotnet4']['version']
   nt_version = node['platform_version'].to_f
+  package_info = node['ms_dotnet']['v4'][version]
 
-  if nt_version >= node['ms_dotnet4']['min_nt_version']
-    windows_package node['ms_dotnet4']['name'] do
-      source          node['ms_dotnet4']['url']
-      checksum        node['ms_dotnet4']['checksum']
+  if nt_version >= package_info['min_nt_version']
+    windows_package package_info['name'] do
+      source          package_info['url']
+      checksum        package_info['checksum']
       installer_type  :custom
       options         '/q /norestart'
       timeout         node['ms_dotnet']['timeout']
       action          :install
-      not_if          nt_version > node['ms_dotnet4']['max_nt_version']
+      not_if          nt_version > package_info['max_nt_version']
       notifies        :request, 'windows_reboot[ms_dotnet]', :immediately
     end
   else
-    Chef::Log.warn('This version of Windows is not supported by .NET ' + node['ms_dotnet4']['version'])
+    Chef::Log.warn('This version of Windows is not supported by .NET ' + version)
   end
 else
   Chef::Log.warn 'Microsoft .NET Framework can only be installed on the Windows platform.'


### PR DESCRIPTION
Remove computation of version's attributes in attributes/ms_dotnet4.rb
Update recipes/ms_dotnet4.rb:
- Remove use of ms_dotnet4 version's attributes
- Use node['ms_dotnet']['v4'][version] attributes
