### PR TITLE
Version 2.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+*~
+*#
+.#*
+\#*#
+.*.sw[a-z]
+*.un~
+pkg/
+
+# Berkshelf
+.vagrant
+/cookbooks
+Berksfile.lock
+
+# Bundler
+Gemfile.lock
+bin/*
+.bundle/*
+
+.kitchen/
+.kitchen.local.yml

--- a/Berksfile
+++ b/Berksfile
@@ -1,0 +1,3 @@
+source "https://api.berkshelf.com"
+
+metadata

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'berkshelf'

--- a/attributes/ms_dotnet4.rb
+++ b/attributes/ms_dotnet4.rb
@@ -18,34 +18,58 @@
 # limitations under the License.
 #
 
-default['ms_dotnet']['v4']['4.0-Client']['name']           = 'Microsoft .NET Framework 4 Client Profile'
-default['ms_dotnet']['v4']['4.0-Client']['url']            = 'http://download.microsoft.com/download/9/5/A/95A9616B-7A37-4AF6-BC36-D6EA96C8DAAE/dotNetFx40_Full_x86_x64.exe'
-default['ms_dotnet']['v4']['4.0-Client']['checksum']       = 'ddb54d46135dc4dd36216eed713f3500b72fc89863a745c3382a0ed493e4b5da'
-default['ms_dotnet']['v4']['4.0-Client']['min_nt_version'] = 5.1
-default['ms_dotnet']['v4']['4.0-Client']['max_nt_version'] = 6.1
+if platform? 'windows'
+  nt_version = node['platform_version'].to_f
+  default['ms_dotnet']['v4']['version']                                   = '4.0'
+  if nt_version >= 5.1 && nt_version <= 6.1
+    default['ms_dotnet']['versions']['4.0']['package']['name']            = 'Microsoft .NET Framework 4 Extended'
+    default['ms_dotnet']['versions']['4.0']['package']['url']             = 'http://download.microsoft.com/download/9/5/A/95A9616B-7A37-4AF6-BC36-D6EA96C8DAAE/dotNetFx40_Full_x86_x64.exe'
+    default['ms_dotnet']['versions']['4.0']['package']['checksum']        = '65e064258f2e418816b304f646ff9e87af101e4c9552ab064bb74d281c38659f'
 
-default['ms_dotnet']['v4']['4.0']['name']                  = 'Microsoft .NET Framework 4 Extended'
-default['ms_dotnet']['v4']['4.0']['url']                   = 'http://download.microsoft.com/download/9/5/A/95A9616B-7A37-4AF6-BC36-D6EA96C8DAAE/dotNetFx40_Full_x86_x64.exe'
-default['ms_dotnet']['v4']['4.0']['checksum']              = '65e064258f2e418816b304f646ff9e87af101e4c9552ab064bb74d281c38659f'
-default['ms_dotnet']['v4']['4.0']['min_nt_version']        = 5.1
-default['ms_dotnet']['v4']['4.0']['max_nt_version']        = 6.1
+    # There is a patch for .NET4
+    default['ms_dotnet']['versions']['4.0']['patch']['name']              = 'Update for Microsoft .NET Framework 4 Extended (KB2468871)'
+    if node['kernel']['machine'] == 'x86_64'
+      default['ms_dotnet']['versions']['4.0']['patch']['url']             = 'http://download.microsoft.com/download/2/B/F/2BF4D7D1-E781-4EE0-9E4F-FDD44A2F8934/NDP40-KB2468871-v2-x64.exe'
+      default['ms_dotnet']['versions']['4.0']['patch']['checksum']        = 'b1b53c3953377b111fe394dd57592d342cfc8a3261a5575253b211c1c2e48ff8'
+    else
+      default['ms_dotnet']['versions']['4.0']['patch']['url']             = 'http://download.microsoft.com/download/2/B/F/2BF4D7D1-E781-4EE0-9E4F-FDD44A2F8934/NDP40-KB2468871-v2-x86.exe'
+      default['ms_dotnet']['versions']['4.0']['patch']['checksum']        = '8822672fc864544e0766c80b635973bd9459d719b1af75f51483ff36cfb26f03'
+    end
+  end
 
-default['ms_dotnet']['v4']['4.5']['name']                  = 'Microsoft .NET Framework 4.5'
-default['ms_dotnet']['v4']['4.5']['url']                   = 'http://download.microsoft.com/download/B/A/4/BA4A7E71-2906-4B2D-A0E1-80CF16844F5F/dotNetFx45_Full_x86_x64.exe'
-default['ms_dotnet']['v4']['4.5']['checksum']              = 'a04d40e217b97326d46117d961ec4eda455e087b90637cb33dd6cc4a2c228d83'
-default['ms_dotnet']['v4']['4.5']['min_nt_version']        = 6.0
-default['ms_dotnet']['v4']['4.5']['max_nt_version']        = 6.1
+  if nt_version >= 6.0
+    if nt_version < 6.1
+      default['ms_dotnet']['versions']['4.5']['package']['name']          = 'Microsoft .NET Framework 4.5'
+      default['ms_dotnet']['versions']['4.5']['package']['url']           = 'http://download.microsoft.com/download/B/A/4/BA4A7E71-2906-4B2D-A0E1-80CF16844F5F/dotNetFx45_Full_x86_x64.exe'
+      default['ms_dotnet']['versions']['4.5']['package']['checksum']      = 'a04d40e217b97326d46117d961ec4eda455e087b90637cb33dd6cc4a2c228d83'
+    end
 
-default['ms_dotnet']['v4']['4.5.1']['name']                = 'Microsoft .NET Framework 4.5.1'
-default['ms_dotnet']['v4']['4.5.1']['url']                 = 'http://download.microsoft.com/download/1/6/7/167F0D79-9317-48AE-AEDB-17120579F8E2/NDP451-KB2858728-x86-x64-AllOS-ENU.exe'
-default['ms_dotnet']['v4']['4.5.1']['checksum']            = '5ded8628ce233a5afa8e0efc19ad34690f05e9bb492f2ed0413508546af890fe'
-default['ms_dotnet']['v4']['4.5.1']['min_nt_version']      = 6.0
-default['ms_dotnet']['v4']['4.5.1']['max_nt_version']      = 6.2
+    if nt_version < 6.2
+      default['ms_dotnet']['versions']['4.5.1']['package']['name']        = 'Microsoft .NET Framework 4.5.1'
+      default['ms_dotnet']['versions']['4.5.1']['package']['url']         = 'http://download.microsoft.com/download/1/6/7/167F0D79-9317-48AE-AEDB-17120579F8E2/NDP451-KB2858728-x86-x64-AllOS-ENU.exe'
+      default['ms_dotnet']['versions']['4.5.1']['package']['checksum']    = '5ded8628ce233a5afa8e0efc19ad34690f05e9bb492f2ed0413508546af890fe'
+    end
 
-default['ms_dotnet']['v4']['4.5.2']['name']                = 'Microsoft .NET Framework 4.5.2'
-default['ms_dotnet']['v4']['4.5.2']['url']                 = 'http://download.microsoft.com/download/E/2/1/E21644B5-2DF2-47C2-91BD-63C560427900/NDP452-KB2901907-x86-x64-AllOS-ENU.exe'
-default['ms_dotnet']['v4']['4.5.2']['checksum']            = '6c2c589132e830a185c5f40f82042bee3022e721a216680bd9b3995ba86f3781'
-default['ms_dotnet']['v4']['4.5.2']['min_nt_version']      = 6.0
-default['ms_dotnet']['v4']['4.5.2']['max_nt_version']      = 6.3
+    default['ms_dotnet']['versions']['4.5.2']['package']['name']          = 'Microsoft .NET Framework 4.5.2'
+    default['ms_dotnet']['versions']['4.5.2']['package']['url']           = 'http://download.microsoft.com/download/E/2/1/E21644B5-2DF2-47C2-91BD-63C560427900/NDP452-KB2901907-x86-x64-AllOS-ENU.exe'
+    default['ms_dotnet']['versions']['4.5.2']['package']['checksum']      = '6c2c589132e830a185c5f40f82042bee3022e721a216680bd9b3995ba86f3781'
 
-default['ms_dotnet4']['version']                           = '4.0'
+    # Starting with windows 8 and Server 2012 old version of .NET Framework 4 are builtin or included as feature
+    if nt_version >= 6.2
+      require 'chef/win32/version'
+      if node['kernel']['os_info']['product_type'] != Chef::ReservedNames::Win32::Version::VER_NT_WORKSTATION
+        feature_name = :builtin # .NET 4 can't be disabled on windows 8 and windows 8.1
+      else
+        feature_name = Chef::ReservedNames::Win32::Version.new.core? && nt_version != 6.3 ? 'netFx4-Server-Core' : 'netFx4'
+      end
+
+      default['ms_dotnet']['versions']['4.0']['feature']                  = feature_name
+      default['ms_dotnet']['versions']['4.5']['feature']                  = feature_name
+      default['ms_dotnet']['versions']['4.5.1']['feature']                = feature_name if nt_version == 6.3
+
+      # .NET 4.5.2 is installed as an update on 2012 & 2012R2
+      hotfix_id = nt_version == 6.3 ? 'KB2934520' : 'KB2901982'
+      default['ms_dotnet']['versions']['4.5.2']['package']['not_if']      = "wmic path Win32_QuickFixEngineering WHERE HotFixID='#{hotfix_id}' | FindStr #{hotfix_id}"
+    end
+  end
+end

--- a/chefignore
+++ b/chefignore
@@ -1,0 +1,98 @@
+# Put files/directories that should be ignored in this file when uploading
+# or sharing to the community site.
+# Lines that start with '# ' are comments.
+
+# OS generated files #
+######################
+.DS_Store
+Icon?
+nohup.out
+ehthumbs.db
+Thumbs.db
+
+# SASS #
+########
+.sass-cache
+
+# EDITORS #
+###########
+\#*
+.#*
+*~
+*.sw[a-z]
+*.bak
+REVISION
+TAGS*
+tmtags
+*_flymake.*
+*_flymake
+*.tmproj
+.project
+.settings
+mkmf.log
+
+## COMPILED ##
+##############
+a.out
+*.o
+*.pyc
+*.so
+*.com
+*.class
+*.dll
+*.exe
+*/rdoc/
+
+# Testing #
+###########
+.watchr
+.rspec
+spec/*
+spec/fixtures/*
+test/*
+features/*
+Guardfile
+Procfile
+
+# SCM #
+#######
+.git
+*/.git
+.gitignore
+.gitmodules
+.gitconfig
+.gitattributes
+.svn
+*/.bzr/*
+*/.hg/*
+*/.svn/*
+
+# Berkshelf #
+#############
+cookbooks/*
+tmp
+
+# Cookbooks #
+#############
+CONTRIBUTING
+CHANGELOG*
+
+# Kitchen #
+##########
+.kitchen.yml
+
+# Strainer #
+############
+Colanderfile
+Strainerfile
+.colander
+.strainer
+
+# Vagrant #
+###########
+.vagrant
+Vagrantfile
+
+# Travis #
+##########
+.travis.yml

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,5 +4,5 @@ maintainer_email 'j_mauro@criteo.com'
 license          'All rights reserved'
 description      'Installs/Configures ms_dotnet'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.2.0'
+version          '2.0.0'
 depends          'windows'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,9 +21,8 @@
 return unless platform?('windows')
 
 include_recipe 'windows'
-unless Chef::Config[:solo] or Chef::Config[:local_mode]
-  include_recipe 'windows::reboot_handler'
-end
+include_recipe 'windows::reboot_handler' unless Chef::Config[:solo] or Chef::Config[:local_mode]
+
 
 windows_reboot 'ms_dotnet' do
   timeout 60

--- a/recipes/ms_dotnet2.rb
+++ b/recipes/ms_dotnet2.rb
@@ -53,6 +53,7 @@ when 'windows'
         checksum node['ms_dotnet2']['checksum']
         installer_type :custom
         options '/quiet /norestart'
+        success_codes [0, 3010]
         timeout node['ms_dotnet']['timeout']
         action :install
         notifies :request, 'windows_reboot[ms_dotnet]', :immediately

--- a/recipes/ms_dotnet2.rb
+++ b/recipes/ms_dotnet2.rb
@@ -24,9 +24,9 @@ when 'windows'
   require 'chef/win32/version'
   windows_version = Chef::ReservedNames::Win32::Version.new
 
-  if (windows_version.windows_server_2008_r2? || windows_version.windows_7?) && windows_version.core?
+  include_recipe 'ms_dotnet'
+  if windows_version.core?
     # Windows Server 2008 R2 Core does not come with .NET or Powershell 2.0 enabled
-
     include_recipe 'ms_dotnet'
     windows_feature 'NetFx2-ServerCore' do
       action :install
@@ -37,7 +37,6 @@ when 'windows'
       only_if { node['kernel']['machine'] == 'x86_64' }
       notifies :request, 'windows_reboot[ms_dotnet]'
     end
-
   elsif windows_version.windows_server_2008? || windows_version.windows_server_2003_r2? ||
     windows_version.windows_server_2003? || windows_version.windows_xp?
 
@@ -48,7 +47,6 @@ when 'windows'
         action :install
       end
     else
-      include_recipe 'ms_dotnet'
       # XP, 2003 and 2003R2 don't have DISM or servermanagercmd, so download .NET 2.0 manually
       windows_package node['ms_dotnet2']['name'] do
         source node['ms_dotnet2']['url']

--- a/recipes/ms_dotnet3.rb
+++ b/recipes/ms_dotnet3.rb
@@ -1,0 +1,34 @@
+#
+# Cookbook Name:: ms_dotnet35
+# Recipe:: default
+#
+# Copyright 2012, Webtrends, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Install .NET 3.5 Feature if we don't find part of the package already installed
+
+if platform?('windows')
+  include_recipe 'ms_dotnet'
+
+  if win_version.windows_server_2008? || win_version.windows_server_2008_r2? || win_version.windows_7? || win_version.windows_vista?
+    windows_feature 'NetFx3' do
+      action :install
+      only_if { File.exists?('C:/Windows/Microsoft.NET/Framework/v3.5') }
+    end
+  elsif win_version.windows_server_2003_r2? || win_version.windows_server_2003? || win_version.windows_xp?
+    Chef::Log.warn('The Microsoft .NET Framework 3.5 Chef recipe currently only supports Windows Vista, 7, 2008, and 2008 R2.')
+  end
+else
+  Chef::Log.warn('Microsoft Framework .NET 3.5 can only be installed on the Windows platform.')
+end

--- a/recipes/regiis.rb
+++ b/recipes/regiis.rb
@@ -20,7 +20,7 @@
 # limitations under the License.
 
 
-execute "aspnet_regiis" do
-  command "%WINDIR%\\Microsoft.Net\\Framework64\\v4.0.30319\\aspnet_regiis -i -enable"
+execute 'aspnet_regiis' do
+  command '%WINDIR%\\Microsoft.Net\\Framework64\\v4.0.30319\\aspnet_regiis -i -enable'
   action :run
 end


### PR DESCRIPTION
Add recipe ms_dotnet3
Fix recipe ms_dotnet2: windows7 core does not exists and install exit code wasn't handled properly
Improve recipe ms_dotnet4:
* Handle all recents Windows server version (2012R2) 
* Handle install exit code
* Handle patch
* Handle Windows Update package (KB)