### PR TITLE
Stop to use ms_dotnet2 attributes

### DIFF
--- a/attributes/ms_dotnet2.rb
+++ b/attributes/ms_dotnet2.rb
@@ -21,15 +21,12 @@
 # Attributes are only needed on Windows 2008 and below.
 if node['platform_version'].to_f <= 6.0
 
-  default['ms_dotnet']['v2']['x64']['url'] = 'http://download.microsoft.com/download/c/6/e/c6e88215-0178-4c6c-b5f3-158ff77b1f38/NetFx20SP2_x64.exe'
-  default['ms_dotnet']['v2']['x64']['checksum'] = '430315c97c57ac158e7311bbdbb7130de3e88dcf5c450a25117c74403e558fbe'
-
-  default['ms_dotnet']['v2']['x86']['url'] = 'http://download.microsoft.com/download/c/6/e/c6e88215-0178-4c6c-b5f3-158ff77b1f38/NetFx20SP2_x86.exe'
-  default['ms_dotnet']['v2']['x86']['checksum'] = '6e3f363366e7d0219b7cb269625a75d410a5c80d763cc3d73cf20841084e851f'
-
-  version = node['kernel']['machine'] == 'x86_64' ? 'x64' : 'x86'
-
-  default['ms_dotnet2']['name'] = 'Microsoft .NET Framework 2.0 Service Pack 2'
-  default['ms_dotnet2']['url'] = node['ms_dotnet']['v2'][version]['url']
-  default['ms_dotnet2']['checksum'] = node['ms_dotnet']['v2'][version]['checksum']
+  default['ms_dotnet']['v2']['name'] = 'Microsoft .NET Framework 2.0 Service Pack 2'
+  if node['kernel']['machine'] == 'x86_64'
+    default['ms_dotnet']['v2']['url'] = 'http://download.microsoft.com/download/c/6/e/c6e88215-0178-4c6c-b5f3-158ff77b1f38/NetFx20SP2_x64.exe'
+    default['ms_dotnet']['v2']['checksum'] = '430315c97c57ac158e7311bbdbb7130de3e88dcf5c450a25117c74403e558fbe'
+  else
+    default['ms_dotnet']['v2']['url'] = 'http://download.microsoft.com/download/c/6/e/c6e88215-0178-4c6c-b5f3-158ff77b1f38/NetFx20SP2_x86.exe'
+    default['ms_dotnet']['v2']['checksum'] = '6e3f363366e7d0219b7cb269625a75d410a5c80d763cc3d73cf20841084e851f'
+  end
 end

--- a/recipes/ms_dotnet2.rb
+++ b/recipes/ms_dotnet2.rb
@@ -48,9 +48,9 @@ when 'windows'
       end
     else
       # XP, 2003 and 2003R2 don't have DISM or servermanagercmd, so download .NET 2.0 manually
-      windows_package node['ms_dotnet2']['name'] do
-        source node['ms_dotnet2']['url']
-        checksum node['ms_dotnet2']['checksum']
+      windows_package node['ms_dotnet']['v2']['name'] do
+        source node['ms_dotnet']['v2']['url']
+        checksum node['ms_dotnet']['v2']['checksum']
         installer_type :custom
         options '/quiet /norestart'
         success_codes [0, 3010]


### PR DESCRIPTION
In order to clean the code:
- Do not use ms_dotnet2 attributes anymore.
- Do not define attributes won't be used.