### PR TITLE
Stop leveraging windows_reboot resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,15 @@ ms_dotnet CHANGELOG
 ===================
 
 This file is used to list changes made in each version of the ms_dotnet cookbook.
-
+2.2.0
+-----
+- b.courtois - Do not use the windows_reboot resource and its request action.
+2.1.1
+-----
+- b.courtois - Update constraint to leverage windows cookbook >=1.36.1
+2.1.0
+-----
+- b.courtois - Fix .NET4.5 support on windows 7/Server 2008R2
 2.0.0
 -----
 - b.courtois - Fail chef run when an invalid .NET4 version is specified

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The following cookbook is required as noted:
 
 * [windows](windows_cookbook) (> 1.36.1)
 
-    `ms_dotnet::default` leverages the windows_reboot LWRP
+    `ms_dotnet::default` include the recipe 'windows::default'
     `ms_dotnet::ms_dotnet2` and `ms_dotnet::ms_dotnet4` leverage the windows_package LWRP
     `ms_dotnet::ms_dotnet2`, `ms_dotnet::ms_dotnet3` and `ms_dotnet::ms_dotnet4` leverage the windows_feature LWRP
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,6 +4,6 @@ maintainer_email 'j_mauro@criteo.com'
 license          'Apache 2.0'
 description      'Installs/Configures ms_dotnet'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.1.1'
+version          '2.2.0'
 supports         'windows'
 depends          'windows', '>= 1.36.1'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,11 +21,3 @@
 return unless platform?('windows')
 
 include_recipe 'windows'
-include_recipe 'windows::reboot_handler' unless Chef::Config[:solo] or Chef::Config[:local_mode]
-
-
-windows_reboot 'ms_dotnet' do
-  timeout 60
-  reason 'Microsoft DotNet Installation'
-  action :nothing
-end

--- a/recipes/ms_dotnet2.rb
+++ b/recipes/ms_dotnet2.rb
@@ -30,12 +30,10 @@ when 'windows'
     include_recipe 'ms_dotnet'
     windows_feature 'NetFx2-ServerCore' do
       action :install
-      notifies :request, 'windows_reboot[ms_dotnet]'
     end
     windows_feature 'NetFx2-ServerCore-WOW64' do
       action :install
       only_if { node['kernel']['machine'] == 'x86_64' }
-      notifies :request, 'windows_reboot[ms_dotnet]'
     end
   elsif windows_version.windows_server_2008? || windows_version.windows_server_2003_r2? ||
     windows_version.windows_server_2003? || windows_version.windows_xp?
@@ -56,7 +54,6 @@ when 'windows'
         success_codes [0, 3010]
         timeout node['ms_dotnet']['timeout']
         action :install
-        notifies :request, 'windows_reboot[ms_dotnet]', :immediately
       end
     end
   else

--- a/recipes/ms_dotnet4.rb
+++ b/recipes/ms_dotnet4.rb
@@ -41,7 +41,6 @@ if platform? 'windows'
       success_codes   [0, 3010]
       timeout         node['ms_dotnet']['timeout']
       action          :install
-      notifies        :request, 'windows_reboot[ms_dotnet]', :immediately
       not_if          package_info['not_if'] if package_info['not_if']
     end
   end
@@ -57,7 +56,6 @@ if platform? 'windows'
       success_codes   [0, 3010]
       timeout         node['ms_dotnet']['timeout']
       action          :install
-      notifies        :request, 'windows_reboot[ms_dotnet]', :immediately
     end
   end
 else


### PR DESCRIPTION
The allow_pending_reboot behavior of the windows reboot handler is more interesting than the windows_reboot; It tries to determine whether windows need a reboot at the end of the chef run instead.

It's still possible for an end-user to create a windows_reboot resource subscribing to the desired .NET "windows_feature" or "windows_package" resource.