### PR TITLE
Skip installing .NET 3.5 if the folder exists

### DIFF
--- a/recipes/ms_dotnet3.rb
+++ b/recipes/ms_dotnet3.rb
@@ -24,7 +24,7 @@ if platform?('windows')
   if win_version.windows_server_2008? || win_version.windows_server_2008_r2? || win_version.windows_7? || win_version.windows_vista?
     windows_feature 'NetFx3' do
       action :install
-      only_if { File.exists?('C:/Windows/Microsoft.NET/Framework/v3.5') }
+      not_if { File.exists?('C:/Windows/Microsoft.NET/Framework/v3.5') }
     end
   elsif win_version.windows_server_2003_r2? || win_version.windows_server_2003? || win_version.windows_xp?
     Chef::Log.warn('The Microsoft .NET Framework 3.5 Chef recipe currently only supports Windows Vista, 7, 2008, and 2008 R2.')


### PR DESCRIPTION
Small bug fix - wouldn't install .NET 3.5 on a new machine as the wrong guard clause was used.