### PR TITLE
Add support .Net Framework 3.5 on Windows 8.1 and 2012 R2

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,11 +20,3 @@
 
 default['ms_dotnet']['timeout'] = 600
 
-if platform? 'windows'
-  nt_version = node['platform_version'].to_f
-  if nt_version >= 6.2
-    default['ms_dotnet']['feature']['enable_all']            = true
-  else
-  	default['ms_dotnet']['feature']['enable_all']            = false
-  end
-end

--- a/attributes/ms_dotnet3.rb
+++ b/attributes/ms_dotnet3.rb
@@ -1,0 +1,29 @@
+#
+# Cookbook Name:: ms_dotnet
+# Attributes:: default
+# Author:: Jeremy MAURo (<j.mauro@criteo.com>)
+#
+# Copyright (C) 2014 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if platform? 'windows'
+  nt_version = node['platform_version'].to_f
+
+  default['ms_dotnet']['v3']['enable_all_features']            = false  
+
+  ## DISM /add is only available on NT Version 6.2 (Windows 8/2012) or newer. 
+  default['ms_dotnet']['v3']['enable_all_features']            = true if nt_version >= 6.2  
+ 
+end

--- a/recipes/ms_dotnet3.rb
+++ b/recipes/ms_dotnet3.rb
@@ -20,10 +20,10 @@
 
 if platform?('windows')
   include_recipe 'ms_dotnet'
-
-  if win_version.windows_server_2008? || win_version.windows_server_2008_r2? || win_version.windows_7? || win_version.windows_vista?
+  if win_version.windows_server_2012? || win_version.windows_server_2012_r2? || win_version.windows_server_2008? || win_version.windows_server_2008_r2? || win_version.windows_7? || win_version.windows_vista?
     windows_feature 'NetFx3' do
       action :install
+      all node['ms_dotnet']['v3']['enable_all_features']
       not_if { File.exists?('C:/Windows/Microsoft.NET/Framework/v3.5') }
     end
   elsif win_version.windows_server_2003_r2? || win_version.windows_server_2003? || win_version.windows_xp?


### PR DESCRIPTION
I am trying to add support for Windows 2012 R2 and 8.1. I was get this to work in my environment by 
turning on enable all dependent Windows feature on Windows 2012. Can someone test this and commit this change into main line. I got a Visual Studio 2008 recipe that depends on this.