### PR TITLE
Don't use win32 api to determine windows version

### DIFF
--- a/attributes/ms_dotnet4.rb
+++ b/attributes/ms_dotnet4.rb
@@ -19,7 +19,7 @@
 #
 
 if platform? 'windows'
-  nt_version = node['platform_version'].to_f
+  nt_version = ::Windows::VersionHelper.nt_version(node)
   default['ms_dotnet']['v4']['version']                                   = '4.0'
   if nt_version >= 5.1 && nt_version <= 6.1
     default['ms_dotnet']['versions']['4.0']['package']['name']            = 'Microsoft .NET Framework 4 Extended'
@@ -56,11 +56,10 @@ if platform? 'windows'
 
     # Starting with windows 8 and Server 2012 old version of .NET Framework 4 are builtin or included as feature
     if nt_version >= 6.2
-      require 'chef/win32/version'
-      if node['kernel']['os_info']['product_type'] != Chef::ReservedNames::Win32::Version::VER_NT_WORKSTATION
+      if ::Windows::VersionHelper.workstation_version?(node)
         feature_name = :builtin # .NET 4 can't be disabled on windows 8 and windows 8.1
       else
-        feature_name = Chef::ReservedNames::Win32::Version.new.core? && nt_version != 6.3 ? 'netFx4-Server-Core' : 'netFx4'
+        feature_name = ::Windows::VersionHelper.core_version?(node) && nt_version != 6.3 ? 'netFx4-Server-Core' : 'netFx4'
       end
 
       default['ms_dotnet']['versions']['4.0']['feature']                  = feature_name

--- a/libraries/windows_version_helper.rb
+++ b/libraries/windows_version_helper.rb
@@ -1,0 +1,74 @@
+#
+# Cookbook Name:: ms_dotnet
+# Library:: windows_version_helper
+# Author:: Baptiste Courtois (<b.courtois@criteo.com>)
+#
+# Copyright (C) 2015 Criteo
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This module should be part of the windows cookbook.
+module Windows
+  # Module based on windows ohai kernel.cs_info providing version helpers
+  module VersionHelper
+    # Module referencing CORE SKU contants from product type
+    # see. https://msdn.microsoft.com/windows/desktop/ms724358#PRODUCT_DATACENTER_SERVER_CORE
+    # n.b. Prefix - PRODUCT_ - and suffix - _CORE- have been removed
+    module CoreSKU
+      # Server Datacenter Core
+      DATACENTER_SERVER   = 0x0C unless defined?(DATACENTER_SERVER)
+      # Server Datacenter without Hyper-V Core
+      DATACENTER_SERVER_V = 0x27 unless defined?(DATACENTER_SERVER_V)
+      # Server Enterprise Core
+      ENTERPRISE_SERVER   = 0x0E unless defined?(ENTERPRISE_SERVER)
+      # Server Enterprise without Hyper-V Core
+      ENTERPRISE_SERVER_V = 0x29 unless defined?(ENTERPRISE_SERVER_V)
+      # Server Standard Core
+      STANDARD_SERVER     = 0x0D unless defined?(STANDARD_SERVER)
+      # Server Standard without Hyper-V Core
+      STANDARD_SERVER_V   = 0x28 unless defined?(STANDARD_SERVER_V)
+    end
+
+    # Determines whether current node is running a windows Core version
+    def self.core_version?(node)
+      validate_platform node
+
+      CoreSKU.constants.any? { |c| CoreSKU.const_get(c) == node['kernel']['os_info']['operating_system_sku'] }
+    end
+
+    # Determine whether current node is a workstation version
+    def self.workstation_version?(node)
+      validate_platform node
+      # see https://msdn.microsoft.com/library/windows/desktop/ms724833#VER_NT_SERVER for product types
+      node['kernel']['os_info']['product_type'] == 0x1
+    end
+
+    # Determine whether current node is a server version
+    def self.server_version?(node)
+      !workstation_version?(node)
+    end
+
+    # Determine NT version of the current node
+    def self.nt_version(node)
+      validate_platform node
+
+      node['platform_version'].to_f
+    end
+
+    private
+
+    def self.validate_platform(node)
+      fail 'Windows helper are only supported on windows platform!' if node['platform'] != 'windows'
+    end
+  end
+end

--- a/libraries/windows_version_helper.rb
+++ b/libraries/windows_version_helper.rb
@@ -18,6 +18,7 @@
 # limitations under the License.
 #
 # This module should be part of the windows cookbook.
+# see: https://github.com/chef-cookbooks/windows/pull/312
 module Windows
   # Module based on windows ohai kernel.cs_info providing version helpers
   module VersionHelper

--- a/recipes/ms_dotnet2.rb
+++ b/recipes/ms_dotnet2.rb
@@ -21,13 +21,11 @@
 case node['platform']
 when 'windows'
 
-  require 'chef/win32/version'
-  windows_version = Chef::ReservedNames::Win32::Version.new
-
   include_recipe 'ms_dotnet'
-  if windows_version.core?
-    # Windows Server 2008 R2 Core does not come with .NET or Powershell 2.0 enabled
-    include_recipe 'ms_dotnet'
+  nt_version = ::Windows::VersionHelper.nt_version(node)
+
+  if nt_version < 6.2 && ::Windows::VersionHelper.core_version?(node)
+  # Windows Server 2008 & 2008R2 Core does not come with .NET or Powershell 2.0 enabled
     windows_feature 'NetFx2-ServerCore' do
       action :install
     end
@@ -35,26 +33,22 @@ when 'windows'
       action :install
       only_if { node['kernel']['machine'] == 'x86_64' }
     end
-  elsif windows_version.windows_server_2008? || windows_version.windows_server_2003_r2? ||
-    windows_version.windows_server_2003? || windows_version.windows_xp?
-
-    if windows_version.windows_server_2008?
-      # Windows PowerShell 2.0 requires version 2.0 of the common language runtime (CLR).
-      # CLR 2.0 is included with the Microsoft .NET Framework versions 2.0, 3.0, or 3.5 with Service Pack 1.
-      windows_feature 'NET-Framework-Core' do
-        action :install
-      end
-    else
-      # XP, 2003 and 2003R2 don't have DISM or servermanagercmd, so download .NET 2.0 manually
-      windows_package node['ms_dotnet']['v2']['name'] do # ~FC009
-        source node['ms_dotnet']['v2']['url']
-        checksum node['ms_dotnet']['v2']['checksum']
-        installer_type :custom
-        options '/quiet /norestart'
-        success_codes [0, 3010]
-        timeout node['ms_dotnet']['timeout']
-        action :install
-      end
+  elsif nt_version == 6.0 && ::Windows::VersionHelper.server_version?(node)
+    # Windows PowerShell 2.0 requires version 2.0 of the common language runtime (CLR).
+    # CLR 2.0 is included with the Microsoft .NET Framework versions 2.0, 3.0, or 3.5 with Service Pack 1.
+    windows_feature 'NET-Framework-Core' do
+      action :install
+    end
+  elsif nt_version.between? 5.1, 5.2
+    # XP, 2003 and 2003R2 don't have DISM or servermanagercmd, so download .NET 2.0 manually
+    windows_package node['ms_dotnet']['v2']['name'] do # ~FC009
+      source node['ms_dotnet']['v2']['url']
+      checksum node['ms_dotnet']['v2']['checksum']
+      installer_type :custom
+      options '/quiet /norestart'
+      success_codes [0, 3010]
+      timeout node['ms_dotnet']['timeout']
+      action :install
     end
   else
     log '.NET Framework 2.0 is already enabled on this version of Windows' do

--- a/recipes/ms_dotnet3.rb
+++ b/recipes/ms_dotnet3.rb
@@ -21,12 +21,11 @@
 if platform?('windows')
   include_recipe 'ms_dotnet'
 
-  nt_version = node['platform_version'].to_f
+  nt_version = ::Windows::VersionHelper.nt_version(node)
 
   if nt_version >= 6.0
     # Windows Server 2012 and earlier have Server features
-    # see https://msdn.microsoft.com/en-us/windows/desktop/ms724358 for product types
-    if nt_version >= 6.2 && node['kernel']['os_info']['product_type'] != 0x1
+    if nt_version >= 6.2 && ::Windows::VersionHelper.server_version?(node)
       feature_name = 'NetFx3ServerFeatures'
     else
       feature_name = 'NetFx3'


### PR DESCRIPTION
Win32 api calls are not easily testable on linux. Chef ohais already retrieve a lot of information about the windows version, leveraging them is easy and fix a lot of issues.

This PR include a library that [might be included in windows cookbook](https://github.com/chef-cookbooks/windows/pull/312) in the future.

cc: @aboten