### PR TITLE
Fix netfx3 activation on 2012 & 2012R2 servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ Attributes
   * `node['ms_dotnet']['v2']['checksum']` - used to configure the checksum of the Windows Package
 
 #### ms_dotnet::ms_dotnet3
-  * `node['ms_dotnet']['v3']['enable_all_features']` - enable all parent features when installing NetFx3 (only supported on NT Version 6.2 or newer, default to `true`)
   * `node['ms_dotnet']['v3']['source']` - used to configure the source of the Windows Package (only supported on NT Version 6.2 or newer)
 
 #### ms_dotnet::ms_dotnet4

--- a/attributes/ms_dotnet3.rb
+++ b/attributes/ms_dotnet3.rb
@@ -19,9 +19,6 @@
 #
 
 if platform? 'windows'
-  # DISM /all is only available on NT Version 6.2 (Windows 8/2012) or newer.
-  default['ms_dotnet']['v3']['enable_all_features'] = true
-
   # DISM /source is only available on NT Version 6.2 (Windows 8/2012) or newer.
   # It can be used to use custom source folder e.g:
   # * Mounted Windows ISO: 'd:\sources\sxs'

--- a/recipes/ms_dotnet3.rb
+++ b/recipes/ms_dotnet3.rb
@@ -24,14 +24,7 @@ if platform?('windows')
   nt_version = ::Windows::VersionHelper.nt_version(node)
 
   if nt_version >= 6.0
-    # Windows Server 2012 and earlier have Server features
-    if nt_version >= 6.2 && ::Windows::VersionHelper.server_version?(node)
-      feature_name = 'NetFx3ServerFeatures'
-    else
-      feature_name = 'NetFx3'
-    end
-
-    windows_feature feature_name do
+    windows_feature 'NetFx3' do
       action :install
 
       # Below attributes are not supported before NT 6.2

--- a/recipes/ms_dotnet3.rb
+++ b/recipes/ms_dotnet3.rb
@@ -30,7 +30,7 @@ if platform?('windows')
       # Below attributes are not supported before NT 6.2
       if nt_version >= 6.2
         source node['ms_dotnet']['v3']['source']
-        all node['ms_dotnet']['v3']['enable_all_features']
+        all true
       end
     end
   else


### PR DESCRIPTION
Hello,

With b315730, we changed the ms_dotnet3 feature from `NetFx3` to `NetFx3ServerFeatures`.

That's a good thing for some cases, but that does not install the core files of the NetFx3 features.
Using the `all` attributes of the `windows_feature` resource, all dependencies of `NetFx3` will be also enabled, including its parent: `NetFx3ServerFeatures`.

Because I think enabling all feature's dependencies is a good pratice, I also remove the attribute controlling this behavior, and enable it always.

cc @aboten