### PR TITLE
Add .NET package & version helpers

### DIFF
--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -1,0 +1,39 @@
+#
+# Cookbook Name:: ms_dotnet
+# Library:: default
+# Author:: Baptiste Courtois (<b.courtois@criteo.com>)
+#
+# Copyright (C) 2015-2016, Criteo.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require_relative 'v2_helper'
+require_relative 'v3_helper'
+require_relative 'v4_helper'
+
+# Library module for cookbook ms_dotnet
+module MSDotNet
+  # Factory method to get VersionHelper for a given major .NET version
+  def self.version_helper(node, major_version)
+    case major_version
+      when 2
+        V2Helper.new node
+      when 3
+        V3Helper.new node
+      when 4
+        V4Helper.new node
+      else
+        raise ArgumentError, "Unsupported version '#{major_version}'"
+    end
+  end
+end

--- a/libraries/package_helper.rb
+++ b/libraries/package_helper.rb
@@ -1,0 +1,137 @@
+#
+# Cookbook Name:: ms_dotnet
+# Library:: package_helper
+# Author:: Baptiste Courtois (<b.courtois@criteo.com>)
+#
+# Copyright (C) 2015-2016, Criteo.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require_relative 'windows_version_helper.rb'
+
+module MSDotNet
+  # References the main official .NET setup and patch packages
+  class PackageHelper
+    attr_reader :arch, :nt_version, :is_core, :is_server, :machine_type
+
+    def initialize(node)
+      @arch = node['kernel']['machine'] == 'x86_64' ? 'x64' : 'x86'
+      @nt_version = ::Windows::VersionHelper.nt_version(node)
+      @is_core = ::Windows::VersionHelper.core_version?(node)
+      @is_server = ::Windows::VersionHelper.server_version?(node)
+
+      @machine_type = if core?
+        :core
+      elsif server?
+        :server
+      else
+        :workstation
+      end
+    end
+
+    def packages
+      @packages ||= ::Mash.new(
+        '2.0.SP2' => {
+          name:     'Microsoft .NET Framework 2.0 Service Pack 2',
+          url:      "https://download.microsoft.com/download/C/6/E/C6E88215-0178-4C6C-B5F3-158FF77B1F38/NetFx20SP2_#{arch}.exe",
+          checksum: x64? ? '430315c97c57ac158e7311bbdbb7130de3e88dcf5c450a25117c74403e558fbe' : '6e3f363366e7d0219b7cb269625a75d410a5c80d763cc3d73cf20841084e851f',
+        },
+        '3.5' => {
+          name:     'Microsoft .NET Framework 3.5',
+          url:      'https://download.microsoft.com/download/6/0/F/60FC5854-3CB8-4892-B6DB-BD4F42510F28/dotnetfx35.exe',
+          checksum: '3e3a4104bad9a0c270ed5cbe8abb986de9afaf0281a98998bdbdc8eaab85c3b6',
+        },
+        '3.5.SP1' => {
+          name:     'Microsoft .NET Framework 3.5 Service Pack 1',
+          url:      'https://download.microsoft.com/download/2/0/E/20E90413-712F-438C-988E-FDAA79A8AC3D/dotnetfx35.exe',
+          checksum: '0582515bde321e072f8673e829e175ed2e7a53e803127c50253af76528e66bc1',
+        },
+        '4.0' => {
+          name:     'Microsoft .NET Framework 4 Extended',
+          url:      'https://download.microsoft.com/download/9/5/A/95A9616B-7A37-4AF6-BC36-D6EA96C8DAAE/dotNetFx40_Full_x86_x64.exe',
+          checksum: '65e064258f2e418816b304f646ff9e87af101e4c9552ab064bb74d281c38659f',
+        },
+        '4.5' => {
+          name:     'Microsoft .NET Framework 4.5',
+          url:      'https://download.microsoft.com/download/B/A/4/BA4A7E71-2906-4B2D-A0E1-80CF16844F5F/dotNetFx45_Full_x86_x64.exe',
+          checksum: 'a04d40e217b97326d46117d961ec4eda455e087b90637cb33dd6cc4a2c228d83',
+        },
+        '4.5.1' => {
+          name:     'Microsoft .NET Framework 4.5.1',
+          url:      'https://download.microsoft.com/download/1/6/7/167F0D79-9317-48AE-AEDB-17120579F8E2/NDP451-KB2858728-x86-x64-AllOS-ENU.exe',
+          checksum: '5ded8628ce233a5afa8e0efc19ad34690f05e9bb492f2ed0413508546af890fe',
+        },
+        '4.5.2' => {
+          name:     'Microsoft .NET Framework 4.5.2',
+          url:      'https://download.microsoft.com/download/E/2/1/E21644B5-2DF2-47C2-91BD-63C560427900/NDP452-KB2901907-x86-x64-AllOS-ENU.exe',
+          checksum: '6c2c589132e830a185c5f40f82042bee3022e721a216680bd9b3995ba86f3781',
+        },
+        '4.6' => {
+          name:     'Microsoft .NET Framework 4.6',
+          url:      'https://download.microsoft.com/download/C/3/A/C3A5200B-D33C-47E9-9D70-2F7C65DAAD94/NDP46-KB3045557-x86-x64-AllOS-ENU.exe',
+          checksum: 'b21d33135e67e3486b154b11f7961d8e1cfd7a603267fb60febb4a6feab5cf87',
+        },
+        '4.6.1' => {
+          name:     'Microsoft .NET Framework 4.6.1',
+          url:      'https://download.microsoft.com/download/E/4/1/E4173890-A24A-4936-9FC9-AF930FE3FA40/NDP461-KB3102436-x86-x64-AllOS-ENU.exe',
+          checksum: 'beaa901e07347d056efe04e8961d5546c7518fab9246892178505a7ba631c301',
+        },
+        ###########
+        # Patches
+        ###########
+        # TODO: handle theses patches
+        # http://www.microsoft.com/en-us/download/details.aspx?id=10006
+        # http://www.microsoft.com/en-us/download/details.aspx?id=1055
+        # http://www.microsoft.com/en-us/download/details.aspx?id=16211
+        # http://www.microsoft.com/en-us/download/details.aspx?id=16921
+        'KB2468871' => {
+          name:     'Update for Microsoft .NET Framework 4 Extended (KB2468871)',
+          url:      "https://download.microsoft.com/download/2/B/F/2BF4D7D1-E781-4EE0-9E4F-FDD44A2F8934/NDP40-KB2468871-v2-#{arch}.exe",
+          checksum: x64? ? 'b1b53c3953377b111fe394dd57592d342cfc8a3261a5575253b211c1c2e48ff8' : '8822672fc864544e0766c80b635973bd9459d719b1af75f51483ff36cfb26f03',
+        },
+        'KB3083186' => {
+          name:     'Update for Microsoft .NET Framework 4.6 (KB3083186)',
+          url:      "https://download.microsoft.com/download/3/E/C/3EC59EE9-5699-4159-9691-E04E38D677CC/NDP46-KB3083186-#{arch}.exe",
+          checksum: x64? ? 'bf850afc7e7987d513fd2c19c9398d014bcbaaeb1691357fa0400529975edace' : '41e675937d023828d648c7a245e19695ed12f890c349d8b6f2b620e6e58e038e',
+          not_if:   'reg query "HKLM\SOFTWARE\Microsoft\Updates\Microsoft .NET Framework 4.6\KB3083186" | FindStr /Ec:"ThisVersionInstalled +REG_SZ +Y"',
+        },
+      ).tap do |packages|
+        # .NET 4.5.2, 4.6 & 4.6.1 are sometimes installed as update on 2012, 2012R2 & 10
+        case nt_version
+          when 6.2
+            { '4.5.2' => 'KB2901982', '4.6' => 'KB3045562', '4.6.1' => 'KB3102439' }
+          when 6.3
+            { '4.5.2' => 'KB2934520', '4.6' => 'KB3045563', '4.6.1' => 'KB3102467' }
+          when 10
+            { '4.6.1' => 'KB3102495' }
+          else
+            {}
+        end.each { |v, kb| packages[v][:not_if] = "C:\\Windows\\System32\\wbem\\wmic.exe QFE where HotFixID='#{kb}' | FindStr #{kb}" }
+      end
+    end
+
+    protected
+
+    def core?
+      is_core
+    end
+
+    def server?
+      is_server
+    end
+
+    def x64?
+      arch == 'x64'
+    end
+  end
+end

--- a/libraries/v2_helper.rb
+++ b/libraries/v2_helper.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+#
+# Cookbook Name:: ms_dotnet
+# Library:: v2_helper
+# Author:: Baptiste Courtois (<b.courtois@criteo.com>)
+#
+# Copyright (C) 2015-2016, Criteo.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require_relative 'version_helper'
+
+module MSDotNet
+  # Provides information about .NET 2 setup
+  class V2Helper < VersionHelper
+    REGISTRY_KEY = 'HKLM/Software/Microsoft/Net Framework Setup/NDP/v2.0.50727/'.freeze unless defined? REGISTRY_KEY
+
+    def installed_version
+      return unless registry_key_exists? REGISTRY_KEY
+
+      values = ::Hash[registry_get_values(REGISTRY_KEY).map { |e| [e[:name], e[:data]] }]
+      case sp = values[:SP].to_i
+        when 0 then '2.0'
+        else "2.0.SP#{sp}"
+      end if values[:Install].to_i == 1
+    end
+
+    def supported_versions
+      @supported_versions ||= %w(2.0.SP2)
+    end
+
+    protected
+
+    def feature_names
+      @feature_names ||= if 6.0 == nt_version && server?
+        %w(NET-Framework-Core)
+      elsif nt_version.between?(6.0, 6.1) && core?
+        x64? ? %w(NetFx2-ServerCore NetFx2-ServerCore-WOW64) : %w(NetFx2-ServerCore)
+      else
+        []
+      end
+    end
+
+    def feature_setup
+      @feature_setup ||= case nt_version
+        # Windows Vista & Server 2008
+        when 6.0, 6.1 then %w(2.0.SP2)
+        # Other versions
+        else []
+      end
+    end
+
+    def patch_names
+      @patch_names ||= {}
+    end
+
+    def package_setup
+      @package_setup ||= case nt_version
+        # Windows XP & Windows Server 2003
+        when 5.1, 5.2 then %w(2.0.SP2)
+        # Other versions
+        else []
+      end
+    end
+  end
+end

--- a/libraries/v3_helper.rb
+++ b/libraries/v3_helper.rb
@@ -1,0 +1,77 @@
+#
+# Cookbook Name:: ms_dotnet
+# Library:: v3_helper
+# Author:: Baptiste Courtois (<b.courtois@criteo.com>)
+#
+# Copyright (C) 2015-2016, Criteo.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require_relative 'version_helper'
+
+module MSDotNet
+  # Provides information about .NET 3 setup
+  class V3Helper < VersionHelper
+    def installed_version
+      # Order is important because we want the maximum version
+      %w(3.5 3.0).find do |version|
+        registry_key = "HKLM/Software/Microsoft/Net Framework Setup/NDP/v#{version}"
+        next unless registry_key_exists? registry_key
+
+        values = ::Hash[registry_get_values(registry_key).map { |e| [e[:name], e[:data]] }]
+        next if values[:Install].to_i != 1
+
+        case sp = values[:SP].to_i
+          when 0 then version
+          else "#{version}.SP#{sp}"
+        end
+      end
+    end
+
+    def supported_versions
+      @supported_versions ||= %w(3.0 3.5 3.5.SP1)
+    end
+
+    protected
+
+    def feature_names
+      @feature_names ||= nt_version >= 6.0 ? %w(NetFx3) : []
+    end
+
+    def feature_setup
+      @feature_setup ||= case nt_version
+        # Vista & Server 2008
+        when 6.0 then %w(3.0)
+        # 7, 8, 8.1, 10 & Server 2008R2, 2012, 2012R2
+        when 6.1, 6.2, 6.3, 10 then %(3.0 3.5 3.5.SP1)
+        # Other versions
+        else []
+      end
+    end
+
+    def patch_names
+      @patch_names ||= {}
+    end
+
+    def package_setup
+      @package_setup ||= case nt_version
+        # Windows XP & Server 2003
+        when 5.2, 5.3 then %w(3.0 3.5 3.5.SP1)
+        # Vista & Server 2008
+        when 6.0 then %w(3.5 3.5.SP1)
+        # Other versions
+        else []
+      end
+    end
+  end
+end

--- a/libraries/v4_helper.rb
+++ b/libraries/v4_helper.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+#
+# Cookbook Name:: ms_dotnet
+# Library:: v4_helper
+# Author:: Baptiste Courtois (<b.courtois@criteo.com>)
+#
+# Copyright (C) 2015-2016, Criteo.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require_relative 'version_helper'
+
+module MSDotNet
+  # Provides information about .NET 4 setup
+  class V4Helper < VersionHelper
+    REGISTRY_KEY = 'HKLM/Software/Microsoft/Net Framework Setup/NDP/v4/Full/'.freeze unless defined? REGISTRY_KEY
+
+    def installed_version
+      return unless registry_key_exists? REGISTRY_KEY
+
+      values = ::Hash[registry_get_values(REGISTRY_KEY).map { |e| [e[:name], e[:data]] }]
+      case values[:Release].to_i
+        when 0 then '4.0'
+        when 378_389 then '4.5'
+        when 378_675, 378_758 then '4.5.1'
+        when 379_893 then '4.5.2'
+        when 393_295, 393_297 then '4.6'
+        when 394_254, 394_271 then '4.6.1'
+      end if values[:Install].to_i == 1
+    end
+
+    def supported_versions
+      @supported_versions ||= %w(4.0 4.5 4.5.1 4.5.2 4.6 4.6.1)
+    end
+
+    protected
+
+    def feature_names
+      @feature_names ||= case nt_version
+        when 6.2, 6.3, 10
+          # TODO: check 2012R2 Core feature name
+          core? ? %w(netFx4-Server-Core) : %w(NetFx4)
+        else
+          []
+      end
+    end
+
+    def feature_setup
+      @feature_setup ||= case nt_version
+        # Windows 8 & Server 2012
+        when 6.2 then %(4.0 4.5)
+        # Windows 8.1 & Server 2012R2
+        when 6.3 then %(4.0 4.5 4.5.1)
+        # Windows 10
+        when 10 then %(4.0 4.5 4.5.1 4.5.2)
+        # Other versions
+        else []
+      end
+    end
+
+    def patch_names
+      @patch_names ||= case nt_version
+        when 5.1, 5.2
+          { '4.0' => %w(KB2468871) }
+        when 6.0, 6.1, 6.2, 6.3, 10
+          { '4.6' => %w(KB3083186) }
+        else
+          {}
+      end
+    end
+
+    def package_setup
+      @package_setup ||= case nt_version
+        # Windows XP & Windows Server 2003
+        when 5.1, 5.2 then %w(4.0)
+        # Windows Vista & Server 2008
+        when 6.0 then %w(4.0 4.5 4.5.1 4.5.2 4.6)
+        # Windows 7 & Server 2008R2
+        when 6.1 then %w(4.0 4.5 4.5.1 4.5.2 4.6 4.6.1)
+        # Windows 8 & Server 2012
+        when 6.2 then %w(4.5.1 4.5.2 4.6 4.6.1)
+        # Windows 8.1 & Server 2012R2
+        when 6.3 then %w(4.5.2 4.6 4.6.1)
+        # Windows 10
+        when 10 then %w(4.6.1)
+        # Other versions
+        else []
+      end
+    end
+  end
+end

--- a/libraries/version_helper.rb
+++ b/libraries/version_helper.rb
@@ -1,0 +1,92 @@
+#
+# Cookbook Name:: ms_dotnet
+# Library:: version_helper
+# Author:: Baptiste Courtois (<b.courtois@criteo.com>)
+#
+# Copyright (C) 2015-2016, Criteo.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require_relative 'package_helper'
+
+module MSDotNet
+  # Base "abstract" class for .NET version helper
+  # Provides method to easily determine how to setup a .NET version
+  class VersionHelper < PackageHelper
+    # Used to detect installed version
+    include ::Chef::DSL::RegistryHelper
+
+    attr_reader :run_context
+
+    def initialize(node)
+      raise TypeError, 'MSDotNet::VersionHelper is an "abstract" class and must not be instanciated directly.' if self.class == ::MSDotNet::VersionHelper
+      super
+
+      # run_context is required by ::Chef::DSL::RegistryHelper
+      @run_context = node.run_context
+    end
+
+    # Get windows features required by the given .NET version
+    def features(version)
+      feature_setup.include?(version) ? feature_names : []
+    end
+
+    # Get installed .NET version on the current node
+    # Returns a String or nil
+    def installed_version
+      raise NotImplementedError
+    end
+
+    # Get windows package required by the given .NET version
+    def package(version)
+      packages[version] if package_setup.include? version
+    end
+
+    # Get windows patches required by the given .NET version
+    def patches(version)
+      (patch_names[version] || []).map { |patch| packages[patch] }
+    end
+
+    # Get all .NET versions supported on the current node OS
+    # Returns an Array<string>
+    def supported_versions
+      raise NotImplementedError
+    end
+
+    protected
+
+    # Get windows feature's names for the major .NET version on the current node OS
+    # Returns an Array<string>
+    def feature_names
+      raise NotImplementedError
+    end
+
+    # Get all .NET versions requiring windows feature activation on the current node OS
+    # Returns an Array<string>
+    def feature_setup
+      raise NotImplementedError
+    end
+
+    # Get patch package's names for each minor .NET versions on the current node OS
+    # Returns a Hash<string,Array<string>> with .NET version as key, and package names as value
+    def patch_names
+      raise NotImplementedError
+    end
+
+    # Get all .NET versions requiring windows package install on the current node OS
+    # Returns an Array<string>
+    def package_setup
+      raise NotImplementedError
+    end
+  end
+end

--- a/spec/libraries/default_spec.rb
+++ b/spec/libraries/default_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe ::MSDotNet do
+  let(:node) { init_node fauxhai_data }
+
+  describe 'version_helper' do
+    it 'returns a new instance of MSDotNet::VersionHelper\'s subclass' do
+      SUPPORTED_MAJOR_VERSIONS.each do |major_version|
+        helper1 = ::MSDotNet.version_helper node, major_version
+        helper2 = ::MSDotNet.version_helper node, major_version
+
+        expect(helper1).to_not eql helper2
+        expect(helper1.is_a?(::MSDotNet::VersionHelper)).to be true
+        expect(helper2.is_a?(::MSDotNet::VersionHelper)).to be true
+      end
+    end
+
+    it 'fails with unsupported version' do
+      expect { ::MSDotNet.version_helper node, -42 }.to raise_error(ArgumentError, /unsupported/i)
+    end
+  end
+end

--- a/spec/libraries/package_helper_spec.rb
+++ b/spec/libraries/package_helper_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+shared_examples 'package_helper' do |data, conf|
+  describe ::MSDotNet::PackageHelper do
+    # Set Core SKU
+    data['kernel']['os_info']['operating_system_sku'] = conf[:core?] ? 0x0D : 0x00
+    # Set arch
+    data['kernel']['machine'] = conf[:x64?] ? 'x86_64' : 'x86'
+    package_helper = ::MSDotNet::PackageHelper.new init_node(data)
+
+    describe 'packages' do
+      it 'returns a Mash' do
+        expect(package_helper.packages).to be_a(Mash)
+      end
+      it 'returns always the same Mash' do
+        expect(package_helper.packages).to be package_helper.packages
+      end
+    end
+
+    [:x64?, :core?, :server?].each do |function|
+      describe function do
+        it "returns #{conf[function]}" do
+          expect(package_helper.send(function)).to be conf[function]
+        end
+      end
+    end
+  end
+end
+
+FAUXHAI_WINDOWS_VERSIONS.each do |windows_version, version_support|
+  # load the data
+  data = fauxhai_data 'windows', windows_version
+  is_server = version_support[:server]
+
+  version_support[:arch].each do |arch|
+    is_64 = arch == '64'
+
+    describe "On Windows#{windows_version}-#{arch}" do
+      include_examples 'package_helper', data, x64?: is_64, server?: is_server, core?: false
+    end
+
+    describe "On Windows#{windows_version}-#{arch}-CORE" do
+      include_examples 'package_helper', data, x64?: is_64, server?: is_server, core?: true
+    end if version_support[:core]
+  end
+end

--- a/spec/libraries/version_helper_spec.rb
+++ b/spec/libraries/version_helper_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe ::MSDotNet::VersionHelper do
+  class TestVersionHelper < ::MSDotNet::VersionHelper; end
+  let(:node) { init_node fauxhai_data }
+  subject(:test_helper) { TestVersionHelper.new node }
+
+  describe 'initialize' do
+    it 'fails when called not inherited' do
+      expect { ::MSDotNet::VersionHelper.new node }.to raise_error(TypeError, /abstract/i)
+    end
+  end
+
+  %w(
+    installed_version
+    supported_versions
+    feature_names
+    feature_setup
+    patch_names
+    package_setup
+  ).each do |abstract_method|
+    describe abstract_method do
+      it 'fails with NotImplementedError' do
+        expect { test_helper.send abstract_method.to_sym }.to raise_error NotImplementedError
+      end
+    end
+  end
+end

--- a/spec/libraries/vx_helper_spec.rb
+++ b/spec/libraries/vx_helper_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+UNSUPPORTED_VERSIONS = %w(0.42.unsupported).freeze
+FAUXHAI_WINDOWS_VERSIONS.keys.each do |windows_version|
+  describe "On Windows#{windows_version}" do
+    let(:node) { init_node fauxhai_data('windows', windows_version) }
+
+    SUPPORTED_MAJOR_VERSIONS.each do |major_version|
+      describe ::MSDotNet.const_get("V#{major_version}Helper") do
+        # Small lambda to check if a hash looks like a package
+        let(:package_like) { ->(hash) { %w(name url checksum).all? { |k| hash.key? k } } }
+        let(:version_helper) { ::MSDotNet.version_helper node, major_version }
+
+        describe 'installed_version' do
+          it 'checks the registry to detect the latest version installed' do
+            expect(version_helper).to receive(:registry_key_exists?).at_least :once
+            expect { version_helper.installed_version }.to_not raise_error
+          end
+        end
+
+        describe 'features' do
+          it 'returns a - possibly empty - array of feature names' do
+            (version_helper.supported_versions + UNSUPPORTED_VERSIONS).each do |version|
+              expect(version_helper.features(version)).to be_an(Array).and all be_a(String)
+            end
+          end
+        end
+
+        describe 'package' do
+          it 'returns a hash with package info or nil' do
+            (version_helper.supported_versions + UNSUPPORTED_VERSIONS).each do |version|
+              expect(version_helper.package(version)).to be_nil.or satisfy(&package_like)
+            end
+          end
+        end
+
+        describe 'patches' do
+          it 'returns a - possibly empty - array of patch packages' do
+            (version_helper.supported_versions + UNSUPPORTED_VERSIONS).each do |version|
+              expect(version_helper.patches(version)).to be_an(Array).and all satisfy(&package_like)
+            end
+          end
+        end
+
+        describe 'supported_versions' do
+          it 'returns a non-empty String array parsable by Gem::Version' do
+            result = version_helper.supported_versions
+            expect(result).to be_an Array
+            expect(result).to_not be_empty
+            expect(result).to all(be_a(String).and(satisfy { |version| ::Gem::Version.new version }))
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,29 @@
 require 'chefspec'
 require 'chefspec/berkshelf'
 
+require_relative '../libraries/default.rb'
+
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
   config.order = 'random'
 end
+
+def fauxhai_data(platform = 'windows', version = '2012R2')
+  ::Fauxhai::Mocker.new(platform: platform, version: version).data
+end
+
+def init_node(hash = {})
+  ::Chef::Node.new.tap { |node| hash.each { |k, v| node.normal[k] = v } }
+end
+
+SUPPORTED_MAJOR_VERSIONS = [2, 3, 4].freeze
+
+FAUXHAI_WINDOWS_VERSIONS = {
+  '8' => { arch: %w(x86 x64), core: false, server: false },
+  '8.1' => { arch: %w(x86 x64), core: false, server: false },
+  '10' => { arch: %w(x86 x64), core: false, server: false },
+  '2003R2' => { arch: %w(x86 x64), core: false, server: true },
+  '2008R2' => { arch: %w(x64), core: true, server: true },
+  '2012' => { arch: %w(x64), core: true, server: true },
+  '2012R2' => { arch: %w(x64), core: true, server: true },
+}.freeze


### PR DESCRIPTION
Add multiple helpers libraries:
* package_helper to get official .NET packages info
* version_helper a base class for .NET setup info
  - v2_helper: subclass for .NET 2 setup
  - v3_helper: subclass for .NET 3 & 3.5 setup
  - v4_helper: subclass for .NET 4, 4.5 & 4.6 setup
* Add unit tests for these helpers

This'll be used soon to create a new LWRP and refactor all recipes.

cc. @aboten @criteo-cookbooks/sre-core 