### PR TITLE
Fix .NET framework installed version check

### DIFF
--- a/libraries/v2_helper.rb
+++ b/libraries/v2_helper.rb
@@ -23,7 +23,7 @@ require_relative 'version_helper'
 module MSDotNet
   # Provides information about .NET 2 setup
   class V2Helper < VersionHelper
-    REGISTRY_KEY = 'HKLM/Software/Microsoft/Net Framework Setup/NDP/v2.0.50727/'.freeze unless defined? REGISTRY_KEY
+    REGISTRY_KEY = 'HKLM\Software\Microsoft\Net Framework Setup\NDP\v2.0.50727'.freeze unless defined? REGISTRY_KEY
 
     def installed_version
       return unless registry_key_exists? REGISTRY_KEY

--- a/libraries/v3_helper.rb
+++ b/libraries/v3_helper.rb
@@ -24,17 +24,15 @@ module MSDotNet
   class V3Helper < VersionHelper
     def installed_version
       # Order is important because we want the maximum version
-      %w(3.5 3.0).find do |version|
-        registry_key = "HKLM/Software/Microsoft/Net Framework Setup/NDP/v#{version}"
+      %w(3.5 3.0).each do |version|
+        registry_key = "HKLM\\Software\\Microsoft\\Net Framework Setup\\NDP\\v#{version}"
         next unless registry_key_exists? registry_key
 
         values = ::Mash[registry_get_values(registry_key).map { |e| [e[:name], e[:data]] }]
         next if values[:Install].to_i != 1
 
-        case sp = values[:SP].to_i
-          when 0 then version
-          else "#{version}.SP#{sp}"
-        end
+        # return from installed_version method - not only the each loop
+        return values[:SP].to_i == '0' ? version : "#{version}.SP#{values[:SP]}"
       end
     end
 

--- a/libraries/v4_helper.rb
+++ b/libraries/v4_helper.rb
@@ -23,7 +23,7 @@ require_relative 'version_helper'
 module MSDotNet
   # Provides information about .NET 4 setup
   class V4Helper < VersionHelper
-    REGISTRY_KEY = 'HKLM/Software/Microsoft/Net Framework Setup/NDP/v4/Full/'.freeze unless defined? REGISTRY_KEY
+    REGISTRY_KEY = 'HKLM\Software\Microsoft\Net Framework Setup\NDP\v4\Full'.freeze unless defined? REGISTRY_KEY
 
     def installed_version
       return unless registry_key_exists? REGISTRY_KEY

--- a/providers/framework.rb
+++ b/providers/framework.rb
@@ -84,6 +84,7 @@ def unsupported?
 end
 
 def install_required?
+  # If current version == desired version; we need to pass by install steps to ensure everything is OK
   @current_resource.nil? || ::Gem::Version.new(version) >= ::Gem::Version.new(@current_resource.version)
 end
 


### PR DESCRIPTION
* Add comment on the `installed_required?` helper.
* Use backslashes .NET registry keys.
* Properly detect SP in v3_helper.

cc. @aboten, @criteo-cookbooks/sre-core 