### PR TITLE
Add KB2919442 as .NET 4.6 prerequisites

### DIFF
--- a/libraries/package_helper.rb
+++ b/libraries/package_helper.rb
@@ -105,6 +105,16 @@ module MSDotNet
           checksum: x64? ? 'bf850afc7e7987d513fd2c19c9398d014bcbaaeb1691357fa0400529975edace' : '41e675937d023828d648c7a245e19695ed12f890c349d8b6f2b620e6e58e038e',
           not_if:   'reg query "HKLM\SOFTWARE\Microsoft\Updates\Microsoft .NET Framework 4.6\KB3083186" | FindStr /Ec:"ThisVersionInstalled +REG_SZ +Y"',
         },
+        'KB2919442' => {
+          name:     'Update for Microsoft Windows (KB2919442)',
+          url:      if x64?
+                      'https://download.microsoft.com/download/D/6/0/D60ED3E0-93A5-4505-8F6A-8D0A5DA16C8A/Windows8.1-KB2919442-x64.msu'
+                    else
+                      'https://download.microsoft.com/download/9/D/A/9DA6C939-9E65-4681-BBBE-A8F73A5C116F/Windows8.1-KB2919442-x86.msu'
+                    end,
+          options:  '/norestart /quiet',
+          checksum: x64? ? 'c10787e669b484674584a990e069295e8b81b5366f98508010a3ae181b729482' : '3368c3a329f402fd982b15b399368627b96973f008a5456b5286bdfc10c1169b',
+        },
         'KB2919355' => {
           name:     'Update for Microsoft Windows (KB2919355)',
           url:      if x64?
@@ -121,7 +131,7 @@ module MSDotNet
           when 6.2
             { '4.5.2' => 'KB2901982', '4.6' => 'KB3045562', '4.6.1' => 'KB3102439' }
           when 6.3
-            { '4.5.2' => 'KB2934520', '4.6' => 'KB3045563', '4.6.1' => 'KB3102467', 'KB2919355' => 'KB2919355' }
+            { '4.5.2' => 'KB2934520', '4.6' => 'KB3045563', '4.6.1' => 'KB3102467', 'KB2919442' => 'KB2919442', 'KB2919355' => 'KB2919355' }
           when 10
             { '4.6.1' => 'KB3102495' }
           else

--- a/libraries/package_helper.rb
+++ b/libraries/package_helper.rb
@@ -105,17 +105,15 @@ module MSDotNet
           checksum: x64? ? 'bf850afc7e7987d513fd2c19c9398d014bcbaaeb1691357fa0400529975edace' : '41e675937d023828d648c7a245e19695ed12f890c349d8b6f2b620e6e58e038e',
           not_if:   'reg query "HKLM\SOFTWARE\Microsoft\Updates\Microsoft .NET Framework 4.6\KB3083186" | FindStr /Ec:"ThisVersionInstalled +REG_SZ +Y"',
         },
-        'KB2919355-x64' => {
+        'KB2919355' => {
           name:     'Update for Microsoft Windows (KB2919355)',
-          url:      'https://download.microsoft.com/download/2/5/6/256CCCFB-5341-4A8D-A277-8A81B21A1E35/Windows8.1-KB2919355-x64.msu',
+          url:      if x64?
+                      'https://download.microsoft.com/download/2/5/6/256CCCFB-5341-4A8D-A277-8A81B21A1E35/Windows8.1-KB2919355-x64.msu'
+                    else
+                      'https://download.microsoft.com/download/4/E/C/4EC66C83-1E15-43FD-B591-63FB7A1A5C04/Windows8.1-KB2919355-x86.msu'
+                    end,
           options:  '/norestart /quiet',
-          checksum: 'b0c9ada530f5ee90bb962afa9ed26218c582362315e13b1ba97e59767cb7825d',
-        },
-        'KB2919355-x86' => {
-          name:     'Update for Microsoft Windows (KB2919355)',
-          url:      'https://download.microsoft.com/download/4/E/C/4EC66C83-1E15-43FD-B591-63FB7A1A5C04/Windows8.1-KB2919355-x86.msu',
-          options:  '/norestart /quiet',
-          checksum: 'f8beca5b463a36e1fef45ad0dca6a0de7606930380514ac1852df5ca6e3f6c1d',
+          checksum: x64? ? 'b0c9ada530f5ee90bb962afa9ed26218c582362315e13b1ba97e59767cb7825d' : 'f8beca5b463a36e1fef45ad0dca6a0de7606930380514ac1852df5ca6e3f6c1d',
         },
       ).tap do |packages|
         # Some packages are installed as QFE updates on 2012, 2012R2 & 10
@@ -123,7 +121,7 @@ module MSDotNet
           when 6.2
             { '4.5.2' => 'KB2901982', '4.6' => 'KB3045562', '4.6.1' => 'KB3102439' }
           when 6.3
-            { '4.5.2' => 'KB2934520', '4.6' => 'KB3045563', '4.6.1' => 'KB3102467', "KB2919355-#{arch}" => 'KB2919355' }
+            { '4.5.2' => 'KB2934520', '4.6' => 'KB3045563', '4.6.1' => 'KB3102467', 'KB2919355' => 'KB2919355' }
           when 10
             { '4.6.1' => 'KB3102495' }
           else

--- a/libraries/v4_helper.rb
+++ b/libraries/v4_helper.rb
@@ -102,7 +102,7 @@ module MSDotNet
     def prerequisite_names
       @patch_names ||= case nt_version
         when 6.3
-          prerequisites_46 = %w(KB2919355)
+          prerequisites_46 = %w(KB2919442 KB2919355)
           { '4.6' => prerequisites_46, '4.6.1' => prerequisites_46 }
         else
           {}

--- a/libraries/v4_helper.rb
+++ b/libraries/v4_helper.rb
@@ -102,7 +102,7 @@ module MSDotNet
     def prerequisite_names
       @patch_names ||= case nt_version
         when 6.3
-          prerequisites_46 = ["KB2919355-#{arch}"]
+          prerequisites_46 = %w(KB2919355)
           { '4.6' => prerequisites_46, '4.6.1' => prerequisites_46 }
         else
           {}


### PR DESCRIPTION
In order to fix #24, we need to install the prerequisites of the prerequisites :)

KB2919355 depends on KB2919442!

Cc: @aboten, @criteo-cookbooks/sre-core 
