### PR TITLE
Fix invalid prerequisites instance variable name

### DIFF
--- a/libraries/v2_helper.rb
+++ b/libraries/v2_helper.rb
@@ -76,7 +76,7 @@ module MSDotNet
     end
 
     def prerequisite_names
-      @patch_names ||= {}
+      @prerequisite_names ||= {}
     end
   end
 end

--- a/libraries/v3_helper.rb
+++ b/libraries/v3_helper.rb
@@ -72,7 +72,7 @@ module MSDotNet
     end
 
     def prerequisite_names
-      @patch_names ||= {}
+      @prerequisite_names ||= {}
     end
   end
 end

--- a/libraries/v4_helper.rb
+++ b/libraries/v4_helper.rb
@@ -103,7 +103,7 @@ module MSDotNet
     end
 
     def prerequisite_names
-      @patch_names ||= case nt_version
+      @prerequisite_names ||= case nt_version
         when 6.3
           prerequisites46 = %w(KB3021910 KB2919355)
           {


### PR DESCRIPTION
Prerequisites were using the same instance variable as patches.

**Cc:** @aboten, @criteo-cookbooks/sre-core 