### PR TITLE
 Perform needed reboots inside ms_dotnet_framework 

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Install the Microsoft .NET Framework.
 
 Requirements
 ------------
-This cookbook supports Chef 11.10.0+
+This cookbook supports and requires Chef 12.1+ to take advantage of the `reboot` and `windows_package` built-in resources.
 
 ### Platforms
 * Windows XP
@@ -23,7 +23,7 @@ The following cookbook is required as noted:
 
 * [windows](windows_cookbook) (> 1.36.1)
 
-    `ms_dotnet_framework` LWRP leverage the windows_package LWRP
+    `ms_dotnet_framework` LWRP leverage the `windows_feature` LWRP
 
 Known Issues
 ------------
@@ -54,6 +54,7 @@ Resource/Provider
 * `version` - Name attribute. Specify the .NET version to install.
 * `include_patches` - Determine whether patches should also be applied (default: `true`)
 * `feature_source` - Specify custom source for windows features. Only avaiable on NT Version 6.2 (Windows 8/2012) or newer. (default: `nil`)
+* `perform_reboot` - Determine whether chef should perform required reboot after installing new packages or feature. (default: `false`)
 * `package_sources` - Specify custom sources URL for windows packages. URL are indexed by their content SHA256 checkum.  (default: `{}`)
 * `require_support` - Determine whether chef should fail when given version is not supported on the current OS (default: `false`)
 
@@ -66,6 +67,7 @@ Install .NET 4.5.2 from custom sources
 ms_dotnet_framework '4.5.2' do
   action            :install
   include_patches   true
+  perform_reboot    true
   package_sources   { '6c2c589132e830a185c5f40f82042bee3022e721a216680bd9b3995ba86f3781' => 'http://my-own.site.com/NetFx452.exe' }
   require_support   true
 end
@@ -86,6 +88,7 @@ Recipes `ms_dotnet2`, `ms_dotnet3` and `ms_dotnet4` are controlled by the follow
 * `version` - Specify the .NET version to install (default: `2.0.SP2`, `3.5.SP1`, `4.0`)
 * `include_patches` - Determine whether patches should also be applied (default: `true`)
 * `feature_source` - Specify custom source for windows features. Only avaiable on NT Version 6.2 (Windows 8/2012) or newer. (default: `nil`)
+* `perform_reboot` - Determine whether chef should perform required reboot after installing new packages or feature. (default: `false`)
 * `package_sources` - Specify custom sources URL for windows packages. URL are indexed by their content SHA256 checkum.  (default: `{}`)
 * `require_support` - Determine whether chef should fail when given version is not supported on the current OS (default: `false`)
 
@@ -120,7 +123,7 @@ Custom node file to install .NET 4.5.2 from a custom site:
       "v4": {
         "version": "4.5.2",
         "package_sources": {
-          "6c2c589132e830a185c5f40f82042bee3022e721a216680bd9b3995ba86f3781": "://my-own.site.com/NetFx452.exe"
+          "6c2c589132e830a185c5f40f82042bee3022e721a216680bd9b3995ba86f3781": "http://my-own.site.com/NetFx452.exe"
         }
       }
     }

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -25,6 +25,7 @@ default['ms_dotnet']['timeout'] = 600
 default['ms_dotnet']['v2']['version']         = '2.0.SP2'
 default['ms_dotnet']['v2']['include_patches'] = true
 default['ms_dotnet']['v2']['feature_source']  = nil
+default['ms_dotnet']['v2']['perform_reboot']  = false
 default['ms_dotnet']['v2']['package_sources'] = {}
 default['ms_dotnet']['v2']['require_support'] = false
 
@@ -32,6 +33,7 @@ default['ms_dotnet']['v2']['require_support'] = false
 default['ms_dotnet']['v3']['version']         = '3.5.SP1'
 default['ms_dotnet']['v3']['include_patches'] = true
 default['ms_dotnet']['v3']['feature_source']  = nil
+default['ms_dotnet']['v3']['perform_reboot']  = false
 default['ms_dotnet']['v3']['package_sources'] = {}
 default['ms_dotnet']['v3']['require_support'] = false
 
@@ -39,5 +41,6 @@ default['ms_dotnet']['v3']['require_support'] = false
 default['ms_dotnet']['v4']['version']         = '4.0'
 default['ms_dotnet']['v4']['include_patches'] = true
 default['ms_dotnet']['v4']['feature_source']  = nil
+default['ms_dotnet']['v4']['perform_reboot']  = false
 default['ms_dotnet']['v4']['package_sources'] = {}
 default['ms_dotnet']['v4']['require_support'] = false

--- a/libraries/v2_helper.rb
+++ b/libraries/v2_helper.rb
@@ -76,7 +76,7 @@ module MSDotNet
     end
 
     def prerequisite_names
-      @patch_names ||= {}
+      @prerequisite_names ||= {}
     end
   end
 end

--- a/libraries/v3_helper.rb
+++ b/libraries/v3_helper.rb
@@ -72,7 +72,7 @@ module MSDotNet
     end
 
     def prerequisite_names
-      @patch_names ||= {}
+      @prerequisite_names ||= {}
     end
   end
 end

--- a/libraries/v4_helper.rb
+++ b/libraries/v4_helper.rb
@@ -103,7 +103,7 @@ module MSDotNet
     end
 
     def prerequisite_names
-      @patch_names ||= case nt_version
+      @prerequisite_names ||= case nt_version
         when 6.3
           prerequisites46 = %w(KB3021910 KB2919355)
           {

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,6 +8,6 @@ version          '3.0.0'
 supports         'windows'
 depends          'windows', '>= 1.36.1'
 
-chef_version '>= 11.10' if respond_to?(:chef_version)
+chef_version '>= 12.1' if respond_to?(:chef_version)
 source_url 'https://github.com/criteo-cookbooks/ms_dotnet' if respond_to?(:source_url)
 issues_url 'https://github.com/criteo-cookbooks/ms_dotnet/issues' if respond_to?(:issues_url)

--- a/recipes/ms_dotnet2.rb
+++ b/recipes/ms_dotnet2.rb
@@ -25,6 +25,7 @@ ms_dotnet_framework v2_info['version'] do
   timeout           node['ms_dotnet']['timeout']
   include_patches   v2_info['include_patches']
   feature_source    v2_info['feature_source'] unless v2_info['feature_source'].nil?
+  perform_reboot    v2_info['perform_reboot']
   package_sources   v2_info['package_sources']
   require_support   v2_info['require_support']
 end

--- a/recipes/ms_dotnet3.rb
+++ b/recipes/ms_dotnet3.rb
@@ -25,6 +25,7 @@ ms_dotnet_framework v3_info['version'] do
   timeout           node['ms_dotnet']['timeout']
   include_patches   v3_info['include_patches']
   feature_source    v3_info['feature_source'] unless v3_info['feature_source'].nil?
+  perform_reboot    v3_info['perform_reboot']
   package_sources   v3_info['package_sources']
   require_support   v3_info['require_support']
 end

--- a/recipes/ms_dotnet4.rb
+++ b/recipes/ms_dotnet4.rb
@@ -25,6 +25,7 @@ ms_dotnet_framework v4_info['version'] do
   timeout           node['ms_dotnet']['timeout']
   include_patches   v4_info['include_patches']
   feature_source    v4_info['feature_source'] unless v4_info['feature_source'].nil?
+  perform_reboot    v4_info['perform_reboot']
   package_sources   v4_info['package_sources']
   require_support   v4_info['require_support']
 end

--- a/resources/framework.rb
+++ b/resources/framework.rb
@@ -25,6 +25,7 @@ provides :ms_dotnet_framework, os: 'windows' if respond_to?(:provides)
 attribute :feature_source,  default: nil,         kind_of: [String, nil]
 attribute :include_patches, default: true,        kind_of: [TrueClass, FalseClass]
 attribute :package_sources, default: {}.freeze,   kind_of: Hash
+attribute :perform_reboot,  default: false,       kind_of: [TrueClass, FalseClass]
 attribute :require_support, default: false,       kind_of: [TrueClass, FalseClass]
 attribute :timeout,         default: 600,         kind_of: Integer
 attribute :version,         name_attribute: true, kind_of: String

--- a/test/cookbooks/ms_dotnet-test/recipes/framework_install.rb
+++ b/test/cookbooks/ms_dotnet-test/recipes/framework_install.rb
@@ -23,6 +23,7 @@ ms_dotnet_framework 'install' do
   timeout           fwk_info['timeout']         unless fwk_info['timeout'].nil?
   include_patches   fwk_info['include_patches'] unless fwk_info['include_patches'].nil?
   feature_source    fwk_info['feature_source']  unless fwk_info['feature_source'].nil?
+  perform_reboot    fwk_info['perform_reboot']  unless fwk_info['perform_reboot'].nil?
   package_sources   fwk_info['package_sources'] unless fwk_info['package_sources'].nil?
   require_support   fwk_info['require_support'] unless fwk_info['require_support'].nil?
 end


### PR DESCRIPTION
As mentioned in #32, some .NET versions have prerequisites requiring a reboot to complete their setup.
Leverage the Chef 12.1+ `reboot` resource to properly stop the chef run and perform this reboot.
Add new `perform_reboot` property to the `ms_dotnet_framework` ressource to control this behavior.

This cookbook now depends on Chef `12.1+`. Metadata and README have been updated accordingly.

This should fix #32 

**Cc:** @aboten, @criteo-cookbooks/sre-core 