### PR TITLE
chef-client 12.6+ windows_package renamed success_codes to returns

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description      'Installs/Configures ms_dotnet'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '3.1.1'
 supports         'windows'
-depends          'windows', '>= 1.36.1'
+depends          'windows', '>= 3.0'
 
 chef_version '>= 12.1' if respond_to?(:chef_version)
 source_url 'https://github.com/criteo-cookbooks/ms_dotnet' if respond_to?(:source_url)

--- a/providers/framework.rb
+++ b/providers/framework.rb
@@ -71,7 +71,7 @@ def install_packages
     windows_package pkg[:name] do # ~FC009 ~FC022
       action          :install
       installer_type  :custom
-      success_codes   [0, 3010]
+      returns         [0, 3010]
       options         pkg[:options] || '/q /norestart'
       timeout         new_resource.timeout
       # Package specific info


### PR DESCRIPTION
Windows 3.0.0 cookbook removed windows_package resource in favor of the built in chef-client one. Chef-client one renamed success_codes option to returns.