### PR TITLE
Tweak to make it work properly when there was no previous .Net 4 keys

### DIFF
--- a/resources/framework.rb
+++ b/resources/framework.rb
@@ -31,7 +31,7 @@ property :version, String, name_property: true
 
 load_current_value do |desired|
   version_helper = ::MSDotNet.version_helper node, desired.version.to_i
-  version version_helper.installed_version unless version_helper.installed_version.nil?
+  version version_helper.installed_version.nil? ? '0' : version_helper.installed_version
 end
 
 action :install do


### PR DESCRIPTION
When testing on 2012/2012R2, I missed the condition where there .net 4 reg keys were totally missing, so the .net 4 installs on 2008R2 would fail.

This fixes that behavior.

Signed-off-by: Steven Murawski <steven.murawski@gmail.com>