### PR TITLE
README: fix ms_dotnet_framework resource example

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ Install .NET 4.5.2 from custom sources
 
 ```ruby
 ms_dotnet_framework '4.5.2' do
-  include_patches true
-  perform_reboot true
+  action            :install
+  include_patches   true
+  perform_reboot    true
   package_sources('6c2c589132e830a185c5f40f82042bee3022e721a216680bd9b3995ba86f3781' => 'http://my-own.site.com/NetFx452.exe')
-  require_support true
-  action :install
+  require_support   true
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ Install .NET 4.5.2 from custom sources
 
 ```ruby
 ms_dotnet_framework '4.5.2' do
-  action            :install
-  include_patches   true
-  perform_reboot    true
-  package_sources   { '6c2c589132e830a185c5f40f82042bee3022e721a216680bd9b3995ba86f3781' => 'http://my-own.site.com/NetFx452.exe' }
-  require_support   true
+  include_patches true
+  perform_reboot true
+  package_sources('6c2c589132e830a185c5f40f82042bee3022e721a216680bd9b3995ba86f3781' => 'http://my-own.site.com/NetFx452.exe')
+  require_support true
+  action :install
 end
 ```
 


### PR DESCRIPTION
Add parenthesis to `package_sources` hash. Also fix some formatting.

Fixes https://github.com/criteo-cookbooks/ms_dotnet/issues/47