### PR TITLE
Remove KB2919422 from Server 2012 R2 prerequesites list.  KB2919422 w…

### DIFF
--- a/libraries/v4_helper.rb
+++ b/libraries/v4_helper.rb
@@ -106,7 +106,7 @@ module MSDotNet
     def prerequisite_names
       @prerequisite_names ||= case nt_version
         when 6.3
-          prerequisites46 = %w(KB2919442 KB2919355 KB3173424)
+          prerequisites46 = %w(KB2919355 KB3173424)
           {
             '4.6' => prerequisites46,
             '4.6.1' => prerequisites46,


### PR DESCRIPTION
KB2919422 is failing to install on a server 2012 r2 machine stating that it is not applicable to the system.