### PR TITLE
Make sure we install required packages

### DIFF
--- a/resources/framework.rb
+++ b/resources/framework.rb
@@ -118,7 +118,7 @@ action_class do
 
   def install_required?
     # If current version == desired version; we need to pass by install steps to ensure everything is OK
-    current_resource.nil? || ::Gem::Version.new(new_resource.version) > ::Gem::Version.new(current_resource.version)
+    current_resource.nil? || ::Gem::Version.new(new_resource.version) >= ::Gem::Version.new(current_resource.version)
   end
 
   def package


### PR DESCRIPTION
When checking for version, especially if we either have not installed the
package before, or want to install 2 versions of the .Net framework; before
this, if 4.6.1 was installed, 3.5.SP1 will not be considered as
install_required? This makes the comment accurate, too, and reverts to the
previous code that was in providers.