### PR TITLE
Clarify behavior on superseded .NET minor version

### DIFF
--- a/spec/providers/framework_spec.rb
+++ b/spec/providers/framework_spec.rb
@@ -36,7 +36,7 @@ describe 'ms_dotnet_framework' do
 
         it 'logs an information message' do
           allow(::Chef::Log).to receive(:info)
-          expect(::Chef::Log).to receive(:info).with '.NET `4.0\' is not needed because .NET `4.5.1\' is already installed'
+          expect(::Chef::Log).to receive(:info).with '.NET `4.0\' has been superseded by .NET `4.5.1\'. Nothing to do!'
           run_chef('windows', '2012R2', version: '4.0')
         end
       end


### PR DESCRIPTION
The former implementation of the `install_required?` helper was meant
to avoid non-idempotent behavior when a more recent .NET minor version
is already present.

There was ambiguity due to the name of the helper and the value of the
log sent in case it returned `false`.

As discussed in #55, I renamed the helper and reversed the logic to
clarify the behavior. The log message is also updated.

*Cc:* @aboten