### PR TITLE
Properly handled .NET 4 versions on windows 10

### DIFF
--- a/libraries/package_helper.rb
+++ b/libraries/package_helper.rb
@@ -20,10 +20,11 @@
 module MSDotNet
   # References the main official .NET setup and patch packages
   class PackageHelper
-    attr_reader :arch, :nt_version, :is_core, :is_server, :machine_type
+    attr_reader :arch, :full_version, :nt_version, :is_core, :is_server, :machine_type
 
     def initialize(node)
       @arch = node['kernel']['machine'] == 'x86_64' ? 'x64' : 'x86'
+      @full_version = node['platform_version']
       @nt_version = ::Windows::VersionHelper.nt_version(node)
       @is_core = ::Windows::VersionHelper.core_version?(node)
       @is_server = ::Windows::VersionHelper.server_version?(node)

--- a/libraries/v4_helper.rb
+++ b/libraries/v4_helper.rb
@@ -90,19 +90,25 @@ module MSDotNet
     end
 
     def package_setup
-      @package_setup ||= case nt_version
+      @package_setup ||= case full_version
         # Windows XP & Windows Server 2003
-        when 5.1, 5.2 then %w(4.0)
+        when /^5.0/, /^5.1/ then %w(4.0)
         # Windows Vista & Server 2008
-        when 6.0 then %w(4.0 4.5 4.5.1 4.5.2 4.6)
+        when /^6.0/ then %w(4.0 4.5 4.5.1 4.5.2 4.6)
         # Windows 7 & Server 2008R2
-        when 6.1 then %w(4.0 4.5 4.5.1 4.5.2 4.6 4.6.1 4.6.2)
+        when /^6.1/ then %w(4.0 4.5 4.5.1 4.5.2 4.6 4.6.1 4.6.2)
         # Windows 8 & Server 2012
-        when 6.2 then %w(4.5.1 4.5.2 4.6 4.6.1)
+        when /^6.2/ then %w(4.5.1 4.5.2 4.6 4.6.1)
         # Windows 8.1 & Server 2012R2
-        when 6.3 then %w(4.5.2 4.6 4.6.1 4.6.2)
-        # Windows 10 & Server 2016
-        when 10 then %w(4.6.1 4.6.2)
+        when /^6.3/ then %w(4.5.2 4.6 4.6.1 4.6.2)
+        # Windows 10 RTM
+        when '10.0.10240' then %w(4.6.1 4.6.2 4.7)
+        # Windows 10 v1511 (November Update)
+        when '10.0.10586' then %w(4.6.2 4.7)
+        # Windows 10 v1607 (Anniversary Update) & Server 2016
+        when '10.0.14393' then %w(4.7)
+        # Windows 10 v1703 (Creative Update)
+        when '10.0.15063' then []
         # Other versions
         else []
       end


### PR DESCRIPTION
Windows 10 embedds different versions of .NET depending of its release.
Former code based on NT Version but this is not precise enough, whereas
using the full Windows version it's possible.

Fix #66 

*Cc.* @aboten, @jmauro 