### PR TITLE
Add new reboot resource performing check on notify

### DIFF
--- a/resources/reboot.rb
+++ b/resources/reboot.rb
@@ -1,0 +1,45 @@
+#
+# Cookbook Name:: ms_dotnet
+# Resource:: reboot
+# Author:: Baptiste Courtois (<b.courtois@criteo.com>)
+#
+# Copyright (C) 2017, Criteo.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# The provides method is available on chef >= 12.0 only
+provides :ms_dotnet_reboot, os: 'windows' if respond_to?(:provides)
+
+property :source, [String, Resource], desired_state: false
+
+action :reboot_if_pending do
+  source_name = source || 'ms_dotnet_framework'
+  reboot "Reboot for #{source_name}" do
+    action   :reboot_now
+    reason   "Reboot by chef for #{source_name}"
+    only_if  { reboot_pending? }
+  end
+end
+
+# Override run_action to store the notifying_resource!
+def run_action(action, notification_type = nil, notifying_resource = nil)
+  source(notifying_resource) if source.nil? && !notifying_resource.nil?
+  super
+end
+
+action_class do
+  def whyrun_supported?
+    true
+  end
+end

--- a/spec/resources/framework_spec.rb
+++ b/spec/resources/framework_spec.rb
@@ -46,21 +46,16 @@ describe 'ms_dotnet_framework' do
         it 'does install packages or features' do
           chef_run = run_chef('windows', '2012R2', version: '4.5.2')
           # ChefSpec matchers doesn't allow `.or`
-          expect(install_windows_feature(/.*/).matches?(chef_run) || install_windows_package(/.*/).matches?(chef_run)).to be true
+          expect(chef_run).to install_windows_package('Microsoft .NET Framework 4.5.2')
         end
         it 'does not reboot if not asked' do
           chef_run = run_chef('windows', '2012R2', version: '4.5.2', perform_reboot: false)
-          expect(chef_run).not_to now_reboot(/^Reboot for ms_dotnet package/)
-        end
-        it 'does not reboot if asked but no reboot are pending' do
-          expect_any_instance_of(::Chef::DSL::RebootPending).to receive(:reboot_pending?).and_return false
-          chef_run = run_chef('windows', '2012R2', version: '4.5.2', perform_reboot: true)
-          expect(chef_run).not_to now_reboot(/^Reboot for ms_dotnet package/)
+          expect(chef_run).not_to reboot_if_pending_ms_dotnet_reboot('Reboot for ms_dotnet[install]')
+          expect(chef_run.windows_package('Microsoft .NET Framework 4.5.2')).not_to notify('ms_dotnet_reboot[Reboot for ms_dotnet[install]]')
         end
         it 'reboots if asked' do
-          expect_any_instance_of(::Chef::DSL::RebootPending).to receive(:reboot_pending?).and_return true
           chef_run = run_chef('windows', '2012R2', version: '4.5.2', perform_reboot: true)
-          expect(chef_run).to now_reboot(/^Reboot for ms_dotnet package/)
+          expect(chef_run.windows_package('Microsoft .NET Framework 4.5.2')).to notify('ms_dotnet_reboot[Reboot for ms_dotnet[install]]')
         end
       end
 

--- a/spec/resources/reboot_spec.rb
+++ b/spec/resources/reboot_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe 'ms_dotnet_reboot' do
+  describe 'action reboot_if_pending' do
+    def run_chef(platform = 'windows', version = '2012R2', reboot_info = { action: 'reboot_if_pending' })
+      ::ChefSpec::SoloRunner.new(platform: platform, version: version, log_level: :fatal, step_into: ['ms_dotnet_reboot']) do |node|
+        reboot_info.each do |key, value|
+          node.default['ms_dotnet_test']['reboot'][key] = value
+        end
+      end.converge 'ms_dotnet-test::reboot'
+    end
+
+    context 'on non Windows platform' do
+      it 'fails' do
+        expect { run_chef 'centos', '7.0' }.to raise_error(/Cannot find a resource for ms_dotnet_reboot/)
+      end
+    end
+
+    context 'on Windows' do
+      it 'does nothing if no reboot is pending' do
+        expect_any_instance_of(::Chef::DSL::RebootPending).to receive(:reboot_pending?).and_return false
+        expect(run_chef).not_to reboot_now_reboot('Reboot for ms_dotnet_framework')
+      end
+      it 'triggers the reboot if reboot was pending' do
+        expect_any_instance_of(::Chef::DSL::RebootPending).to receive(:reboot_pending?).and_return true
+        expect(run_chef).to reboot_now_reboot('Reboot for ms_dotnet_framework')
+      end
+      it 'automatically computes the source when notified' do
+        expect_any_instance_of(::Chef::DSL::RebootPending).to receive(:reboot_pending?).and_return false
+        reboot_resource = run_chef.ms_dotnet_reboot('now')
+        expect(reboot_resource.source).to be_nil
+        # Trigger notification manually, because Chefspec disable them
+        reboot_resource.run_action :reboot_if_pending, :immediately, 'notifying_resource1'
+
+        expect(reboot_resource.source).to eq 'notifying_resource1'
+      end
+    end
+  end
+end

--- a/test/cookbooks/ms_dotnet-test/recipes/reboot.rb
+++ b/test/cookbooks/ms_dotnet-test/recipes/reboot.rb
@@ -1,0 +1,22 @@
+#
+# Cookbook Name:: ms_dotnet-test
+# Recipe:: reboot
+# Author:: Baptiste Courtois (<b.courtois@criteo.com>)
+#
+# Copyright (C) 2015-2016, Criteo.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+ms_dotnet_reboot 'now' do
+  action node['ms_dotnet_test']['reboot']['action']
+end


### PR DESCRIPTION
The ms_dotnet_reboot is not intended to be used by external cookbooks.
It performs reboot on notification only if a reboot is pending.

Fix #55 

*Cc.* @aboten @jmauro