### PR TITLE
Fix various deprecation warnings

### DIFF
--- a/spec/recipes/default_spec.rb
+++ b/spec/recipes/default_spec.rb
@@ -12,7 +12,7 @@ describe 'ms_dotnet::default' do
   end
   describe 'On non-windows platform' do
     let(:chef_run) do
-      ChefSpec::SoloRunner.new.converge(described_recipe)
+      ChefSpec::SoloRunner.new(platform: 'centos', version: '7.3.1611').converge(described_recipe)
     end
 
     it 'does nothing' do

--- a/spec/recipes/ms_dotnet2_spec.rb
+++ b/spec/recipes/ms_dotnet2_spec.rb
@@ -13,7 +13,7 @@ describe 'ms_dotnet::ms_dotnet2' do
 
   describe 'On non-windows platform' do
     let(:chef_run) do
-      ChefSpec::SoloRunner.new.converge(described_recipe)
+      ChefSpec::SoloRunner.new(platform: 'centos', version: '7.3.1611').converge(described_recipe)
     end
 
     it 'does nothing' do

--- a/spec/recipes/ms_dotnet3_spec.rb
+++ b/spec/recipes/ms_dotnet3_spec.rb
@@ -13,7 +13,7 @@ describe 'ms_dotnet::ms_dotnet3' do
 
   describe 'On non-windows platform' do
     let(:chef_run) do
-      ChefSpec::SoloRunner.new.converge(described_recipe)
+      ChefSpec::SoloRunner.new(platform: 'centos', version: '7.3.1611').converge(described_recipe)
     end
 
     it 'does nothing' do

--- a/spec/recipes/ms_dotnet4_spec.rb
+++ b/spec/recipes/ms_dotnet4_spec.rb
@@ -13,7 +13,7 @@ describe 'ms_dotnet::ms_dotnet4' do
 
   describe 'On non-windows platform' do
     let(:chef_run) do
-      ChefSpec::SoloRunner.new.converge(described_recipe)
+      ChefSpec::SoloRunner.new(platform: 'centos', version: '7.3.1611').converge(described_recipe)
     end
 
     it 'does nothing' do

--- a/spec/recipes/regiis_spec.rb
+++ b/spec/recipes/regiis_spec.rb
@@ -16,7 +16,7 @@ describe 'ms_dotnet::regiis' do
   end
   describe 'On non-windows platform' do
     let(:chef_run) do
-      ChefSpec::SoloRunner.new.converge(described_recipe)
+      ChefSpec::SoloRunner.new(platform: 'centos', version: '7.3.1611').converge(described_recipe)
     end
 
     it 'does nothing' do

--- a/spec/resources/framework_spec.rb
+++ b/spec/resources/framework_spec.rb
@@ -12,7 +12,7 @@ describe 'ms_dotnet_framework' do
 
     context 'on non Windows platform' do
       it 'fails' do
-        expect { run_chef 'centos', '7.0' }.to raise_error(/Cannot find a resource for ms_dotnet_framework/)
+        expect { run_chef 'centos', '7.3.1611' }.to raise_error(/Cannot find a resource for ms_dotnet_framework/)
       end
     end
 

--- a/spec/resources/reboot_spec.rb
+++ b/spec/resources/reboot_spec.rb
@@ -12,7 +12,7 @@ describe 'ms_dotnet_reboot' do
 
     context 'on non Windows platform' do
       it 'fails' do
-        expect { run_chef 'centos', '7.0' }.to raise_error(/Cannot find a resource for ms_dotnet_reboot/)
+        expect { run_chef 'centos', '7.3.1611' }.to raise_error(/Cannot find a resource for ms_dotnet_reboot/)
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,10 +35,8 @@ end
 SUPPORTED_MAJOR_VERSIONS = [2, 3, 4].freeze
 
 FAUXHAI_WINDOWS_VERSIONS = {
-  '8' => { arch: %w(x86 x64), core: false, server: false },
   '8.1' => { arch: %w(x86 x64), core: false, server: false },
   '10' => { arch: %w(x86 x64), core: false, server: false },
-  '2003R2' => { arch: %w(x86 x64), core: false, server: true },
   '2008R2' => { arch: %w(x64), core: true, server: true },
   '2012' => { arch: %w(x64), core: true, server: true },
   '2012R2' => { arch: %w(x64), core: true, server: true },


### PR DESCRIPTION
- ChefSpec Runner must specify a platform and version.
- Fauxhai platform data for centos 7.0 is deprecated, use 7.3 instead.
- Remove deprecated Fauxhai Windows versions.