### PR TITLE
Adds reboot delay attribute

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,6 +20,7 @@
 return unless platform? 'windows'
 
 default['ms_dotnet']['timeout'] = 600
+default['ms_dotnet']['reboot']['delay'] = 1
 
 # .NET 2 attributes
 default['ms_dotnet']['v2']['version']         = '2.0.SP2'

--- a/chefignore
+++ b/chefignore
@@ -79,6 +79,7 @@ CHANGELOG*
 
 # Kitchen #
 ##########
+.kitchen
 .kitchen.yml
 
 # Strainer #

--- a/resources/reboot.rb
+++ b/resources/reboot.rb
@@ -24,11 +24,12 @@ provides :ms_dotnet_reboot, os: 'windows' if respond_to?(:provides)
 property :source, [String, Resource], desired_state: false
 
 action :reboot_if_pending do
-  source_name = source || 'ms_dotnet_framework'
+  source_name = new_resource.source || 'ms_dotnet_framework'
   reboot "Reboot for #{source_name}" do
-    action   :reboot_now
-    reason   "Reboot by chef for #{source_name}"
-    only_if  { reboot_pending? }
+    action :reboot_now
+    delay_mins node['ms_dotnet']['reboot']['delay']
+    reason "Reboot by chef for #{source_name}"
+    only_if { reboot_pending? }
   end
 end
 


### PR DESCRIPTION
Adds reboot delay attribute so users can override the `delay_mins` when utilizing the `perform_reboot` within the `ms_dotnet_framework` resource.

This is better defaulted to 1 so that the Chef run has time to exit prior to the server rebooting, but 0 is the current value when not specified. Thoughts on changing this?
