### PR TITLE
Add patch KB4054856 for .NET 4.7.1

### DIFF
--- a/libraries/package_helper.rb
+++ b/libraries/package_helper.rb
@@ -185,6 +185,13 @@ module MSDotNet
           checksum: 'f50efbd614094ebe84b0bccb0f89903e5619e5a380755d0e8170e8e893af7a9f',
           not_if: %w(KB4019990),
         },
+        'KB4054856' => {
+          name:     'Update for Microsoft Windows (KB4054856)',
+          url:      'https://download.microsoft.com/download/8/5/E/85E5D4E2-7D95-40F7-AB83-9DBFCFBDBE6E/NDP471-KB4054856-x86-x64-AllOS.exe',
+          options:  '/norestart /quiet',
+          checksum: 'f98d12d84c803699d149a254ada3dd5dc0698307638e1baae209cc6f3a729e29',
+          not_if:   %w(KB4054852 KB4054853 KB4054854 KB4054855),
+        },
       )
     end
 

--- a/libraries/v4_helper.rb
+++ b/libraries/v4_helper.rb
@@ -76,15 +76,17 @@ module MSDotNet
     end
 
     def patch_names
-      @patch_names ||= case nt_version
-        when 5.1, 5.2
+      @patch_names ||= case full_version
+        when /^5\.1/, /^5\.2/
           { '4.0' => %w(KB2468871) }
-        when 6.0, 6.1
-          { '4.6' => %w(KB3083186) }
-        when 6.2
-          { '4.6' => %w(KB3083184) }
-        when 6.3
-          { '4.6' => %w(KB3083185) }
+        when /^6\.0/, /^6\.1/
+          { '4.6' => %w(KB3083186), '4.7.1' => %w(KB4054856) }
+        when /^6\.2/
+          { '4.6' => %w(KB3083184), '4.7.1' => %w(KB4054856) }
+        when /^6\.3/
+          { '4.6' => %w(KB3083185), '4.7.1' => %w(KB4054856) }
+        when '10.0.10240', '10.0.10586', '10.0.14393', '10.0.15063'
+          { '4.7.1' => %w(KB4054856) }
         else
           {}
       end
@@ -93,15 +95,15 @@ module MSDotNet
     def package_setup
       @package_setup ||= case full_version
         # Windows XP & Windows Server 2003
-        when /^5.0/, /^5.1/ then %w(4.0)
+        when /^5\.0/, /^5\.1/ then %w(4.0)
         # Windows Vista & Server 2008
-        when /^6.0/ then %w(4.0 4.5 4.5.1 4.5.2 4.6)
+        when /^6\.0/ then %w(4.0 4.5 4.5.1 4.5.2 4.6)
         # Windows 7 & Server 2008R2
-        when /^6.1/ then %w(4.0 4.5 4.5.1 4.5.2 4.6 4.6.1 4.6.2 4.7 4.7.1)
+        when /^6\.1/ then %w(4.0 4.5 4.5.1 4.5.2 4.6 4.6.1 4.6.2 4.7 4.7.1)
         # Windows 8 & Server 2012
-        when /^6.2/ then %w(4.5.1 4.5.2 4.6 4.6.1 4.6.2 4.7 4.7.1)
+        when /^6\.2/ then %w(4.5.1 4.5.2 4.6 4.6.1 4.6.2 4.7 4.7.1)
         # Windows 8.1 & Server 2012R2
-        when /^6.3/ then %w(4.5.2 4.6 4.6.1 4.6.2 4.7 4.7.1)
+        when /^6\.3/ then %w(4.5.2 4.6 4.6.1 4.6.2 4.7 4.7.1)
         # Windows 10 RTM (TH1)
         when '10.0.10240' then %w(4.6.1 4.6.2 4.7 4.7.1)
         # Windows 10 v1511 (TH2)


### PR DESCRIPTION
.NET 4.7.1 comes with an important patch for backward compatibility.
This patch bundled as KB4054856 install a different update depending on the operation system.

To ease the registration, the patch is added only once to the package helper with the key KB4054856. Then the guard mechanism is used to handle the various KB.

See https://support.microsoft.com/help/4054856
**Cc.** @aboten & @criteo-cookbooks/sre-core-infra 