### PR TITLE
Set require_support to true by default

### DIFF
--- a/resources/framework.rb
+++ b/resources/framework.rb
@@ -25,7 +25,7 @@ property :feature_source,  String
 property :include_patches, [true, false], default: true
 property :package_sources, Hash, default: lazy { ::Mash.new }
 property :perform_reboot, [true, false], default: false
-property :require_support, [true, false], default: false
+property :require_support, [true, false], default: true
 property :timeout, Integer, default: 600
 property :version, String, name_property: true
 


### PR DESCRIPTION
So that run break if a dotnet version is not present
Follow https://github.com/criteo-cookbooks/ms_dotnet/pull/100

We can set any version to any attribute of type default ['ms_dotnet'] ['vX'] ['version'] (example for v4 -> 4.9.9). It will continue and do nothing without notifying or throwing an exception.

With attribute set to default['ms_dotnet']['v4']['version'] = '4.9.9'

Will result in :

[2021-09-27T12:12:51+00:00] INFO: Processing ms_dotnet_framework[4.9.9] action install (ms_dotnet::ms_dotnet4 line 24)
[2021-09-27T12:12:51+00:00] INFO: Unsupported .NET version: 4.9.9

Which does nothing and does not break the run.