### PR TITLE
Add support for Github CI

### DIFF
--- a/.github/workflows/criteo-cookbooks-ci.yml
+++ b/.github/workflows/criteo-cookbooks-ci.yml
@@ -1,0 +1,45 @@
+# This is a basic workflow to help you get started with Actions
+name: Criteo Cookbooks CI
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  rspec:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.5
+          bundler-cache: true
+      - run: bundle exec rubocop --version
+      - run: bundle exec rubocop
+      - run: bundle exec foodcritic --version
+      - run: bundle exec foodcritic . --exclude spec -f any
+      - run: bundle exec rspec
+  kitchen:
+    needs: [rspec]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        windows_version: ['windows-2012r2', 'windows-2016', 'windows-2019']
+        # dotnet3 use some hacks that are not available on CI
+        dotnet_version: ['dotnet2', 'dotnet4']
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.5
+          bundler-cache: true
+      - run: KITCHEN_LOCAL_YAML=.kitchen.yml bundle exec kitchen verify ${{ matrix.dotnet_version }}-${{ matrix.windows_version }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_SSH_KEY_ID: ${{ secrets.AWS_SSH_KEY_ID }}
+          AWS_SUBNET: ${{ secrets.AWS_SUBNET }}
+          AWS_SECURITY_GROUP: ${{ secrets.AWS_SECURITY_GROUP }}

--- a/.github/workflows/criteo-cookbooks-ci.yml
+++ b/.github/workflows/criteo-cookbooks-ci.yml
@@ -4,6 +4,7 @@ on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
     branches: [ master ]
+    tags: [ 'v*' ]
   pull_request:
     branches: [ master ]
 
@@ -35,7 +36,7 @@ jobs:
         with:
           ruby-version: 2.5
           bundler-cache: true
-      - run: KITCHEN_LOCAL_YAML=.kitchen.yml bundle exec kitchen verify ${{ matrix.dotnet_version }}-${{ matrix.windows_version }}
+      - run: bundle exec kitchen test ${{ matrix.dotnet_version }}-${{ matrix.windows_version }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_REGION: ${{ secrets.AWS_REGION }}
@@ -43,3 +44,17 @@ jobs:
           AWS_SSH_KEY_ID: ${{ secrets.AWS_SSH_KEY_ID }}
           AWS_SUBNET: ${{ secrets.AWS_SUBNET }}
           AWS_SECURITY_GROUP: ${{ secrets.AWS_SECURITY_GROUP }}
+  supermarket:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: [kitchen]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Publish to supermarket
+      uses: afaundez/chef-supermarket-action@8cdbe1cccbe1ecd8685b2ea8f48780135bae7cee
+      with:
+        user: criteo
+        cookbook: ms_dotnet
+        category: Utilities
+      env:
+        SUPERMARKET_API_KEY: ${{ secrets.SUPERMARKET_API_KEY }}

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,37 +1,75 @@
+---
+# The following environment variables are required:
+# - AWS_ACCESS_KEY_ID
+# - AWS_SECRET_ACCESS_KEY
+# - AWS_SSH_KEY_ID
+# - AWS_REGION
+#
+# Optional environment variables:
+# - AWS_SECURITY_GROUP
+# - AWS_SUBNET
+# - KITCHEN_NO_CONCURRENCY set it to true if you do not want concurrency
+
 driver:
-  name: vagrant
-  customize:
-    cpus: 2
-    memory: 4096
+  name: ec2
+  instance_type: t3a.large
+  associate_public_ip: true
+  iam_profile_name: test-kitchen
+  retryable_tries: 120
+  region: <%= ENV['AWS_REGION'] || 'us-west-1' %>
+  tags:
+    created-by: <%= ENV['AWS_SSH_KEY_ID'] %>
+  subnet_filter:
+    tag:   'Name'
+    value: <%= ENV['AWS_SUBNET'] || 'chef-testing-opensource-vpc-subnet' %>
+  security_group_filter:
+    tag:   'Name'
+    value: <%= ENV['AWS_SECURITY_GROUP'] || 'chef-testing-opensource-vpc-security-group' %>
+  block_device_mappings:
+    - device_name: /dev/sda1
+      ebs:
+        volume_type: gp2
+        delete_on_termination: true
 
-transport:
-  name: winrm
-  elevated: true
+  provisioner:
+    name: chef_zero
+    install_strategy: always
+    chef_license: accept
+    client_rb:
+      ssl_verify_mode: :verify_none
+      verify_api_cert: false
+      exit_status: ":enabled"
+      client_fork: false
+      enforce_path_sanity: true
+      file_cache_path: c:/temp
+    retry_on_exit_code:
+    - 35
+    max_retries: 2
+    wait_for_retry: 60
+    product_name: chef
 
-provisioner:
-  name: chef_zero
-  deprecations_as_errors: true
-  retry_on_exit_code:
-    - 35 # 35 is the exit code signaling that the node is rebooting
-  max_retries: 1
-  client_rb:
-    exit_status: :enabled # Opt-in to the standardized exit codes
-    client_fork: false  # Forked instances don't return the real exit code
+  transport:
+    name: winrm
+    elevated: true
+    elevated_username: System
+    elevated_password: 
 
 platforms:
-  - name: windows-7
-    driver_config:
-      box: chef/windows-7-professional
-  - name: windows-8.1
-    driver_config:
-      box: chef/windows-8.1-professional
-  - name: windows-2008r2
-    driver_config:
-      box: chef/windows-server-2008r2-standard
   - name: windows-2012r2
-    driver_config:
-      box: chef/windows-server-2012r2-standard
-
+    driver:
+      image_search:
+        'owner-id': 801119661308
+        name: 'Windows_Server-2012-R2-English-STIG-Full-20*'
+  - name: windows-2016
+    driver:
+      image_search:
+        'owner-id': 801119661308
+        name: 'Windows_Server-2016-English-Full-Base-20*'
+  - name: windows-2019
+    driver:
+      image_search:
+        'owner-id': 801119661308
+        name: 'Windows_Server-2019-English-Full-Base-20*'
 suites:
   - name: dotnet2
     run_list:


### PR DESCRIPTION
Travis CI is broken and now Github has Action CI let's update that.
I had to update some Gems, some are too old, I took the opportunity to re-lint code with newer rules.
Kitchens had to be migrated to EC2 and I had to remove support for Windows 2008 because I couldn't find any official AWS images.
Kitchens for dotnet3 are disabled because they require hacks that will not and cannot be available on CI.