### PR TITLE
Remove dependency on windows and bump chef version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,6 @@ This cookbook supports and requires Chef 12.1+ to take advantage of the `reboot`
 * Windows Server 2012 (R1, R2)
 * Windows Server 2016
 
-### Cookbooks
-The following cookbook is required as noted:
-
-* [windows](windows_cookbook) (>= 2.1.0)
-
-    `ms_dotnet_framework` LWRP leverage the `windows_feature` LWRP
-    `MSDotNet::PackageHelper` class used in `ms_dotnet_framework` leverages the `::Windows::VersionHelper` module.
-
 Known Issues
 ------------
 Here are the known issues you can encounter with ms_dotnet recipes:

--- a/libraries/package_helper.rb
+++ b/libraries/package_helper.rb
@@ -27,9 +27,9 @@ module MSDotNet
     def initialize(node)
       @arch = node['kernel']['machine'] == 'x86_64' ? 'x64' : 'x86'
       @full_version = node['platform_version']
-      @nt_version = ::Windows::VersionHelper.nt_version(node)
-      @is_core = ::Windows::VersionHelper.core_version?(node)
-      @is_server = ::Windows::VersionHelper.server_version?(node)
+      @nt_version = @full_version.to_f
+      @is_core = ::MSDotNet::WindowsVersionHelper.core_version?(node)
+      @is_server = ::MSDotNet::WindowsVersionHelper.server_version?(node)
 
       @machine_type = if core?
         :core

--- a/libraries/windows_version_helper.rb
+++ b/libraries/windows_version_helper.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+#
+# Cookbook:: ms_dotnet
+# Library:: windows_version_helper
+# Author:: Baptiste Courtois (<b.courtois@criteo.com>)
+#
+# Copyright:: 2015-2021, Criteo
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module MSDotNet
+  # Module based on windows ohai kernel.cs_info providing version helpers
+  module WindowsVersionHelper
+    # Module referencing CORE SKU contants from product type
+    # see. https://msdn.microsoft.com/windows/desktop/ms724358#PRODUCT_DATACENTER_SERVER_CORE
+    # n.b. Prefix - PRODUCT_ - and suffix - _CORE- have been removed
+    module CoreSKU
+      # Server Datacenter Core
+      DATACENTER_SERVER   = 0x0C unless constants.include?(:DATACENTER_SERVER)
+      # Server Datacenter without Hyper-V Core
+      DATACENTER_SERVER_V = 0x27 unless constants.include?(:DATACENTER_SERVER_V)
+      # Server Enterprise Core
+      ENTERPRISE_SERVER   = 0x0E unless constants.include?(:ENTERPRISE_SERVER)
+      # Server Enterprise without Hyper-V Core
+      ENTERPRISE_SERVER_V = 0x29 unless constants.include?(:ENTERPRISE_SERVER_V)
+      # Server Standard Core
+      STANDARD_SERVER     = 0x0D unless constants.include?(:STANDARD_SERVER)
+      # Server Standard without Hyper-V Core
+      STANDARD_SERVER_V   = 0x28 unless constants.include?(:STANDARD_SERVER_V)
+      # Small Business Server Premium Core
+      PRODUCT_SMALLBUSINESS_SERVER_PREMIUM_CORE = 0x3F unless constants.include?(:PRODUCT_SMALLBUSINESS_SERVER_PREMIUM_CORE)
+      # Server Solutions Premium Core
+      STANDARD_SERVER_SOLUTIONS = 0x35 unless constants.include?(:STANDARD_SERVER_SOLUTIONS)
+      # Storage Server Enterprise Core
+      STORAGE_ENTERPRISE_SERVER = 0x2E unless constants.include?(:STORAGE_ENTERPRISE_SERVER)
+      # Storage Server Express Core
+      STORAGE_EXPRESS_SERVER = 0x2B unless constants.include?(:STORAGE_EXPRESS_SERVER)
+      # Storage Server Standard Core
+      STORAGE_STANDARD_SERVER = 0x2C unless constants.include?(:STORAGE_STANDARD_SERVER)
+      # Storage Server Workgroup Core
+      STORAGE_WORKGROUP_SERVER = 0x2D unless constants.include?(:STORAGE_WORKGROUP_SERVER)
+      # Web Server Core
+      WEB_SERVER = 0x1D unless constants.include?(:WEB_SERVER)
+    end
+
+    # Module referencing product type contants
+    # see. https://msdn.microsoft.com/windows/desktop/ms724833#VER_NT_SERVER
+    # n.b. Prefix - VER_NT_ - has been removed
+    module ProductType
+      WORKSTATION         = 0x1 unless constants.include?(:WORKSTATION)
+      DOMAIN_CONTROLLER   = 0x2 unless constants.include?(:DOMAIN_CONTROLLER)
+      SERVER              = 0x3 unless constants.include?(:SERVER)
+    end
+
+    # Determines whether current node is running a windows Core version
+    def self.core_version?(node)
+      validate_platform node
+
+      CoreSKU.constants.any? { |c| CoreSKU.const_get(c) == node['kernel']['os_info']['operating_system_sku'] }
+    end
+
+    # Determines whether current node is a workstation version
+    def self.workstation_version?(node)
+      validate_platform node
+      node['kernel']['os_info']['product_type'] == ProductType::WORKSTATION
+    end
+
+    # Determines whether current node is a server version
+    def self.server_version?(node)
+      !workstation_version?(node)
+    end
+
+    # Determines NT version of the current node
+    def self.nt_version(node)
+      validate_platform node
+
+      node['platform_version'].to_f
+    end
+
+    def self.validate_platform(node)
+      raise 'Windows helper are only supported on windows platform!' unless node['platform'] == 'windows'
+    end
+  end
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,8 +8,8 @@ description      'Installs/Configures ms_dotnet'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '4.2.1'
 supports         'windows'
-depends          'windows', '>= 2.1.0'
 
-chef_version '>= 12.6' if respond_to?(:chef_version)
+chef_version '>= 14.7' if respond_to?(:chef_version)
+
 source_url 'https://github.com/criteo-cookbooks/ms_dotnet' if respond_to?(:source_url)
 issues_url 'https://github.com/criteo-cookbooks/ms_dotnet/issues' if respond_to?(:issues_url)

--- a/resources/framework.rb
+++ b/resources/framework.rb
@@ -85,8 +85,7 @@ action_class.class_eval do
       windows_package pkg[:name] do # ~FC009 ~FC022
         action          :install
         installer_type  :custom
-        success_codes   [0, 3010] if respond_to? :success_codes
-        returns         [0, 3010] if respond_to? :returns
+        returns         [0, 3010]
         options         pkg[:options] || '/q /norestart'
         timeout         new_resource.timeout
         # Package specific info

--- a/spec/libraries/package_helper_spec.rb
+++ b/spec/libraries/package_helper_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require_relative '../../libraries/windows_version_helper'
 
 shared_examples 'package_helper' do |data, conf|
   describe ::MSDotNet::PackageHelper do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,10 +13,6 @@ require_relative '../libraries/default.rb'
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
   config.order = 'random'
-
-  config.before(:all) do
-    ::ChefSpec::SoloRunner.new(platform: 'windows', version: '2012R2').converge('windows')
-  end
 end
 
 def fauxhai_data(platform = 'windows', version = '2012R2')


### PR DESCRIPTION
windows_package has been added to Chef a long time ago and the windows cookbook has been deprecated.
Let's use the built-in package resource.

Re-import the Version helper that was defined here first then moved to windows cookbook ^^'